### PR TITLE
fix(specfile): correct path for checkout

### DIFF
--- a/red hat/rtc-testbench.spec
+++ b/red hat/rtc-testbench.spec
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Red Hat
+# Copyright (C) 2024,2025 Red Hat
 # Author Pablo Iranzo Gómez <Pablo.Iranzo@redhat.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
@@ -31,7 +31,7 @@ cd %{_topdir}/BUILD
 rm -rf %{name}-%{version}
 git clone https://github.com/%{myrepo} %{name}-%{version}
 cd %{name}-%{version}
-git checkout v%{version}
+git checkout %{version}
 
 %build
 cd %{_topdir}/BUILD/%{name}-%{version}


### PR DESCRIPTION
There was an extra letter in the git checkout command that was making SPEC file to failure in compilation when using rpmbuild by introducing an extra 'v' for the version we're checking out in the repo.

When building the RPM and SRPM packages with:
`rpmbuild -ba red\ hat/rtc-testbench.spec --define='version v5.2' --define='myrepo Linutronix/RTC-Testbench'`

The command is properly substituting 'version' with 'v5.2' so `git checkout v{version}` was adding an extra `v`.