### PR TITLE
xdp: Fix missing Rx latency when launch time is enabled

### DIFF
--- a/src/xdp.c
+++ b/src/xdp.c
@@ -591,6 +591,7 @@ unsigned int xdp_receive_frames(struct xdp_socket *xsk, size_t frame_length, boo
 		/* Parse it */
 		addr = xsk_umem__add_offset_to_addr(addr);
 		packet = xsk_umem__get_data(xsk->umem.buffer, addr);
+		receive_function(data, packet, len);
 
 		if (mirror_enabled) {
 			struct xdp_desc *tx_desc = xsk_ring_prod__tx_desc(&xsk->tx, idx_tx++);
@@ -606,8 +607,6 @@ unsigned int xdp_receive_frames(struct xdp_socket *xsk, size_t frame_length, boo
 			/* Move buffer back to fill queue */
 			*xsk_ring_prod__fill_addr(&xsk->umem.fq, idx_fq++) = orig;
 		}
-
-		receive_function(data, packet, len);
 	}
 
 	if (mirror_enabled) {


### PR DESCRIPTION
When both Rx latency and launch time are enabled (TxTimeEnabled in the .yaml file), the Rx latency value is missing due to overwritten metadata. The issue occurs because xdp_prepare_tx_desc() writes xsk_tx_metadata into the packet headroom, which still holds the Rx timestamp metadata that has not been processed yet.

Fix this by moving receive_function() earlier to ensure the Rx timestamp metadata is parsed before the headroom is overwritten.