### PR TITLE
stat: Add device latency (RX HW -> TX HW) measurement for mirror mode

### DIFF
--- a/Documentation/build.rst
+++ b/Documentation/build.rst
@@ -89,3 +89,7 @@ and options.
 
    * - Enable TX Hardware Timestamping
      - TX_TIMESTAMP
+  
+   * - Show Device Latency for Mirror Mode (Rx HW to Tx HW timestamp)
+     - RX_TIMESTAMP
+     - TX_TIMESTAMP

--- a/src/log.c
+++ b/src/log.c
@@ -126,6 +126,19 @@ static void log_add_traffic_class(const char *name, enum stat_frame_type frame_t
 	*buffer += written;
 	*length -= written;
 
+	/* Add device latency statistics for mirror mode */
+	if (app_config.classes[frame_type].tx_hwtstamp_enabled && config_have_rx_timestamp() &&
+	    app_config.classes[frame_type].xdp_enabled && stat->device_latency_count > 0) {
+		written =
+			snprintf(*buffer, *length,
+				 "%sDeviceLatencyMin=%" PRIu64 " [us] | %sDeviceLatencyMax=%" PRIu64
+				 " [us] | %sDeviceLatencyAvg=%lf [us] | ",
+				 name, stat->device_latency_min, name, stat->device_latency_max,
+				 name, stat->device_latency_avg);
+		*buffer += written;
+		*length -= written;
+	}
+
 	if (config_have_rx_timestamp() && app_config.classes[frame_type].xdp_enabled) {
 		written = snprintf(*buffer, *length,
 				   "%sRxMin=%" PRIu64 " [us] | %sRxMax=%" PRIu64

--- a/src/logviamqtt.c
+++ b/src/logviamqtt.c
@@ -87,6 +87,9 @@ static void log_via_mqtt_add_traffic_class(struct mosquitto *mosq, const char *m
 			   "\t\t\t\"OnewayMin\" : %" PRIu64 ",\n"
 			   "\t\t\t\"OnewayMax\" : %" PRIu64 ",\n"
 			   "\t\t\t\"OnewayAv\" : %lf,\n"
+			   "\t\t\t\"DeviceLatencyMin\" : %" PRIu64 ",\n"
+			   "\t\t\t\"DeviceLatencyMax\" : %" PRIu64 ",\n"
+			   "\t\t\t\"DeviceLatencyAv\" : %lf,\n"
 			   "\t\t\t\"RxMin\" : %" PRIu64 ",\n"
 			   "\t\t\t\"RxMax\" : %" PRIu64 ",\n"
 			   "\t\t\t\"RxAv\" : %lf,\n"
@@ -110,14 +113,15 @@ static void log_via_mqtt_add_traffic_class(struct mosquitto *mosq, const char *m
 			   "\t\t\t\"OnewayOutliers\" : %" PRIu64 "\n\t\t}",
 			   "stats", name, stat->frames_sent, stat->frames_received,
 			   stat->round_trip_min, stat->round_trip_max, stat->round_trip_avg,
-			   stat->oneway_min, stat->oneway_max, stat->oneway_avg, stat->rx_min,
-			   stat->rx_max, stat->rx_avg, stat->rx_hw2xdp_min, stat->rx_hw2xdp_max,
-			   stat->rx_hw2xdp_avg, stat->rx_xdp2app_min, stat->rx_xdp2app_max,
-			   stat->rx_xdp2app_avg, stat->rx_workload_min, stat->rx_workload_max,
-			   stat->rx_workload_avg, stat->tx_min, stat->tx_max, stat->tx_avg,
-			   stat->tx_hw_timestamp_missing, stat->out_of_order_errors,
-			   stat->frame_id_errors, stat->payload_errors, stat->round_trip_outliers,
-			   stat->oneway_outliers);
+			   stat->oneway_min, stat->oneway_max, stat->oneway_avg,
+			   stat->device_latency_min, stat->device_latency_max,
+			   stat->device_latency_avg, stat->rx_min, stat->rx_max, stat->rx_avg,
+			   stat->rx_hw2xdp_min, stat->rx_hw2xdp_max, stat->rx_hw2xdp_avg,
+			   stat->rx_xdp2app_min, stat->rx_xdp2app_max, stat->rx_xdp2app_avg,
+			   stat->rx_workload_min, stat->rx_workload_max, stat->rx_workload_avg,
+			   stat->tx_min, stat->tx_max, stat->tx_avg, stat->tx_hw_timestamp_missing,
+			   stat->out_of_order_errors, stat->frame_id_errors, stat->payload_errors,
+			   stat->round_trip_outliers, stat->oneway_outliers);
 
 	p += written;
 	stat_message_length -= written;

--- a/src/stat.c
+++ b/src/stat.c
@@ -42,7 +42,7 @@ static struct statistics statistics_per_period_for_log[NUM_FRAME_TYPES];
 
 struct round_trip_context round_trip_contexts[NUM_FRAME_TYPES];
 static uint64_t rtt_expected_rt_limit;
-static int log_stat_user_selected;
+int log_stat_user_selected;
 static FILE *file_tracing_on;
 static FILE *file_trace_marker;
 
@@ -72,6 +72,7 @@ static void stat_reset(struct statistics *stats)
 	stats->rx_xdp2app_min = UINT64_MAX;
 	stats->rx_workload_min = UINT64_MAX;
 	stats->tx_min = UINT64_MAX;
+	stats->device_latency_min = UINT64_MAX;
 }
 
 int stat_init(enum log_stat_options log_selection)
@@ -222,6 +223,16 @@ static inline void stat_update_min_max(uint64_t new_value, uint64_t *min, uint64
 	*min = (new_value < *min) ? new_value : *min;
 }
 
+static inline size_t get_first_frame_backlog_idx(uint64_t cycle_number,
+						 enum stat_frame_type frame_type,
+						 size_t backlog_len)
+{
+	uint64_t first_frame_in_cycle =
+		(cycle_number / app_config.classes[frame_type].num_frames_per_cycle) *
+		app_config.classes[frame_type].num_frames_per_cycle;
+	return first_frame_in_cycle % backlog_len;
+}
+
 static bool stat_frame_received_common(struct statistics *stat, enum stat_frame_type frame_type,
 				       uint64_t rt_time, uint64_t oneway_time, bool out_of_order,
 				       bool payload_mismatch, bool frame_id_mismatch,
@@ -285,6 +296,17 @@ static void stat_frame_sent_latency_common(struct statistics *stat, enum stat_fr
 	stat->tx_sum += tx_latency_us;
 	stat->tx_avg = stat->tx_sum / (double)stat->tx_count;
 }
+
+static void stat_frame_device_latency_common(struct statistics *stat,
+					     enum stat_frame_type frame_type,
+					     uint64_t device_latency_us)
+{
+	stat_update_min_max(device_latency_us, &stat->device_latency_min,
+			    &stat->device_latency_max);
+	stat->device_latency_count++;
+	stat->device_latency_sum += device_latency_us;
+	stat->device_latency_avg = stat->device_latency_sum / (double)stat->device_latency_count;
+}
 #endif
 
 #if defined(WITH_MQTT)
@@ -334,6 +356,14 @@ static void stat_frame_sent_latency_per_period(enum stat_frame_type frame_type,
 
 	stat_frame_sent_latency_common(stat_per_period, frame_type, tx_latency_us);
 }
+
+static void stat_frame_device_latency_per_period(enum stat_frame_type frame_type,
+						 uint64_t device_latency_us)
+{
+	struct statistics *stat_per_period = &statistics_per_period[frame_type];
+
+	stat_frame_device_latency_common(stat_per_period, frame_type, device_latency_us);
+}
 #endif
 #else
 static void stat_frame_received_per_period(enum stat_frame_type frame_type, uint64_t curr_time,
@@ -354,6 +384,11 @@ static void stat_frame_workload_per_period(enum stat_frame_type frame_type, uint
 #ifdef TX_TIMESTAMP
 static void stat_frame_sent_latency_per_period(enum stat_frame_type frame_type,
 					       uint64_t tx_latency_us)
+{
+}
+
+static void stat_frame_device_latency_per_period(enum stat_frame_type frame_type,
+						 uint64_t device_latency_us)
 {
 }
 #endif
@@ -464,6 +499,25 @@ void stat_frame_received(enum stat_frame_type frame_type, uint64_t cycle_number,
 	clock_gettime(app_config.application_clock_id, &rx_time);
 	curr_time = ts_to_ns(&rx_time);
 
+	/* Store RX HW timestamp for device latency measurement at Mirror */
+	if (log_stat_user_selected == LOG_TX_TIMESTAMPS &&
+	    app_config.classes[frame_type].tx_hwtstamp_enabled && config_have_rx_timestamp() &&
+	    rx_hw_timestamp != 0 && rtt->backlog) {
+		/* Check if this is the first frame of the cycle */
+		uint64_t frame_in_cycle =
+			cycle_number % app_config.classes[frame_type].num_frames_per_cycle;
+		if (frame_in_cycle == 0) {
+			size_t idx = get_first_frame_backlog_idx(cycle_number, frame_type,
+								 rtt->backlog_len);
+			rtt->backlog[idx].rx_hw_ts = rx_hw_timestamp;
+
+			log_message(LOG_LEVEL_DEBUG,
+				    "Mirror: Stored RX HW timestamp %" PRIu64 " for cycle %" PRIu64
+				    ", idx=%zu\n",
+				    rx_hw_timestamp, cycle_number, idx);
+		}
+	}
+
 	if (log_stat_user_selected == LOG_REFERENCE) {
 		uint64_t tx_sw_ts;
 		size_t backlog_idx;
@@ -474,11 +528,8 @@ void stat_frame_received(enum stat_frame_type frame_type, uint64_t cycle_number,
 			 * When TX HW timestamping is enabled, only first frame of each cycle has
 			 * timestamp
 			 */
-			uint64_t first_frame_in_cycle =
-				(cycle_number /
-				 app_config.classes[frame_type].num_frames_per_cycle) *
-				app_config.classes[frame_type].num_frames_per_cycle;
-			backlog_idx = first_frame_in_cycle % rtt->backlog_len;
+			backlog_idx = get_first_frame_backlog_idx(cycle_number, frame_type,
+								  rtt->backlog_len);
 			tx_sw_ts = rtt->backlog[backlog_idx].sw_ts;
 		} else {
 			/* When TX HW timestamping is disabled, each frame has its own timestamp */
@@ -544,6 +595,63 @@ void stat_frame_received(enum stat_frame_type frame_type, uint64_t cycle_number,
 		exit(EXIT_SUCCESS);
 	}
 }
+
+#ifdef TX_TIMESTAMP
+void stat_frame_device_latency(enum stat_frame_type frame_type, uint64_t cycle_number,
+			       uint64_t tx_hw_timestamp)
+{
+	struct round_trip_context *rtt = &round_trip_contexts[frame_type];
+	struct statistics *stat = &global_statistics[frame_type];
+	size_t idx = get_first_frame_backlog_idx(cycle_number, frame_type, rtt->backlog_len);
+	uint64_t rx_hw_ts = rtt->backlog[idx].rx_hw_ts;
+
+	/* Ensure both RX and TX hardware timestamps are enabled */
+	if (!config_have_rx_timestamp() || !app_config.classes[frame_type].tx_hwtstamp_enabled) {
+		log_message(LOG_LEVEL_DEBUG,
+			    "Device latency [%s] Cycle %" PRIu64
+			    ": Hardware timestamping not fully enabled (RX: %s, TX: %s)\n",
+			    stat_frame_type_to_string(frame_type), cycle_number,
+			    config_have_rx_timestamp() ? "enabled" : "disabled",
+			    app_config.classes[frame_type].tx_hwtstamp_enabled ? "enabled"
+									       : "disabled");
+		return;
+	}
+
+	if (rx_hw_ts == 0 || tx_hw_timestamp == 0) {
+		log_message(LOG_LEVEL_DEBUG,
+			    "Device latency [%s] Cycle %" PRIu64
+			    ": Missing timestamp (RX HW: %" PRIu64 ", TX HW: %" PRIu64 ")\n",
+			    stat_frame_type_to_string(frame_type), cycle_number, rx_hw_ts,
+			    tx_hw_timestamp);
+		return;
+	}
+
+	if (tx_hw_timestamp > rx_hw_ts) {
+		uint64_t device_latency = (tx_hw_timestamp - rx_hw_ts) / 1000;
+
+		log_message(LOG_LEVEL_DEBUG,
+			    "Device latency [%s] Cycle %" PRIu64 ": %" PRIu64 " us (RX HW: %" PRIu64
+			    ", TX HW: %" PRIu64 ")\n",
+			    stat_frame_type_to_string(frame_type), cycle_number, device_latency,
+			    rx_hw_ts, tx_hw_timestamp);
+
+		/* Update global stats */
+		stat_frame_device_latency_common(stat, frame_type, device_latency);
+
+		/* Update stats per collection interval */
+		stat_frame_device_latency_per_period(frame_type, device_latency);
+
+		/* Clear the stored RX HW timestamp to avoid reuse */
+		rtt->backlog[idx].rx_hw_ts = 0;
+	} else {
+		log_message(LOG_LEVEL_DEBUG,
+			    "Device latency [%s] Cycle %" PRIu64 ": TX HW timestamp (%" PRIu64
+			    ") <= RX HW timestamp (%" PRIu64 ")\n",
+			    stat_frame_type_to_string(frame_type), cycle_number, tx_hw_timestamp,
+			    rx_hw_ts);
+	}
+}
+#endif
 
 void stat_frame_workload(enum stat_frame_type frame_type, uint64_t cycle_number,
 			 struct timespec start_ts)

--- a/src/stat.h
+++ b/src/stat.h
@@ -101,11 +101,18 @@ struct statistics {
 	uint64_t tx_hw_timestamp_missing;
 	double tx_sum;
 	double tx_avg;
+	/* Device latency at Mirror (Rx HW to Tx HW timestamp) */
+	uint64_t device_latency_min;
+	uint64_t device_latency_max;
+	uint64_t device_latency_count;
+	double device_latency_sum;
+	double device_latency_avg;
 };
 
 struct rtt_entry {
 	uint64_t sw_ts;
 	uint64_t hw_ts;
+	uint64_t rx_hw_ts;
 };
 
 struct round_trip_context {
@@ -128,8 +135,11 @@ void stat_get_stats_per_period(struct statistics *stats, size_t len);
 void stat_frame_workload(enum stat_frame_type, uint64_t cycle_number, struct timespec start_ts);
 void stat_inc_workload_outlier(enum stat_frame_type frame_type);
 void stat_frame_sent_latency(enum stat_frame_type frame_type, uint64_t seq);
+void stat_frame_device_latency(enum stat_frame_type frame_type, uint64_t cycle_number,
+			       uint64_t tx_hw_timestamp);
 
 extern volatile sig_atomic_t reset_stats;
 extern struct round_trip_context round_trip_contexts[NUM_FRAME_TYPES];
+extern int log_stat_user_selected;
 
 #endif /* _STAT_H_ */

--- a/tests/busypolling_1ms_rtworkload/mirror_vid100_cml.yaml
+++ b/tests/busypolling_1ms_rtworkload/mirror_vid100_cml.yaml
@@ -22,6 +22,7 @@ TsnHigh:
   TsnHighXdpZcMode: true
   TsnHighXdpWakeupMode: true
   TsnHighXdpBusyPollMode: true
+  TsnHighTxTimeStampEnabled: false
   TsnHighVid: 100
   TsnHighNumFramesPerCycle: 32
   TsnHighPayloadPattern: |

--- a/tests/busypolling_1ms_rtworkload/reference_vid100_cml.yaml
+++ b/tests/busypolling_1ms_rtworkload/reference_vid100_cml.yaml
@@ -22,6 +22,7 @@ TsnHigh:
   TsnHighXdpZcMode: true
   TsnHighXdpWakeupMode: true
   TsnHighXdpBusyPollMode: true
+  TsnHighTxTimeStampEnabled: false
   TsnHighVid: 100
   TsnHighNumFramesPerCycle: 32
   TsnHighPayloadPattern: |


### PR DESCRIPTION
This patch enables device latency measurement based on RX HW and TX HW timestamps in mirror mode. The metric reflects total packet residence time inside the Mirror DUT, measured for the first frame of each cycle.

This feature activates automatically when mirror mode is configured with both XDP and hardware timestamping enabled for RX and TX.

Usage:
- Build with: cmake -DCMAKE_BUILD_TYPE=Release \ -DRX_TIMESTAMP=TRUE \ -DWITH_MQTT=TRUE \ -DTX_TIMESTAMP=TRUE ..

- In the YAML config, enable per-class TX HW timestamping with: <Class>TxTimeStampEnabled: true

Example output in mirror log:
  TsnHighDeviceLatencyMin=998 [us] TsnHighDeviceLatencyMax=1001 [us] TsnHighDeviceLatencyAvg=999.146538