### PR TITLE
stat: Add processing latency metrics for mirror mode

### DIFF
--- a/src/layer2_thread.c
+++ b/src/layer2_thread.c
@@ -323,8 +323,8 @@ static void *generic_l2_xdp_tx_thread_routine(void *data)
 	int ret;
 
 	xsk = thread_context->xsk;
-	xsk->rtt = &round_trip_contexts[GENERICL2_FRAME_TYPE];
-	xsk->tx_hw_ts_seq_lagged = 0;
+	xsk->tx_hwts.rtt = &round_trip_contexts[GENERICL2_FRAME_TYPE];
+	xsk->tx_hwts.frames_per_cycle = l2_config->num_frames_per_cycle;
 
 	ret = get_interface_mac_address(l2_config->interface, source, ETH_ALEN);
 	if (ret < 0) {
@@ -420,7 +420,7 @@ static void *generic_l2_xdp_tx_thread_routine(void *data)
 				 * This is one cycle later than SW timestamp tracked
 				 * using sequence_counter
 				 */
-				xsk->tx_hw_ts_seq_lagged = sequence_counter;
+				xsk->tx_hwts.seq_lagged = sequence_counter;
 			}
 #endif
 

--- a/src/log.c
+++ b/src/log.c
@@ -126,6 +126,28 @@ static void log_add_traffic_class(const char *name, enum stat_frame_type frame_t
 	*buffer += written;
 	*length -= written;
 
+	if (app_config.classes[frame_type].tx_hwtstamp_enabled && config_have_rx_timestamp() &&
+	    app_config.classes[frame_type].xdp_enabled && stat->proc_first_count > 0) {
+		written = snprintf(*buffer, *length,
+				   "%sProcFirstMin=%" PRIu64 " [us] | %sProcFirstMax=%" PRIu64
+				   " [us] | %sProcFirstAvg=%lf [us] | ",
+				   name, stat->proc_first_min, name, stat->proc_first_max, name,
+				   stat->proc_first_avg);
+		*buffer += written;
+		*length -= written;
+	}
+
+	if (app_config.classes[frame_type].tx_hwtstamp_enabled && config_have_rx_timestamp() &&
+	    app_config.classes[frame_type].xdp_enabled && stat->proc_batch_count > 0) {
+		written = snprintf(*buffer, *length,
+				   "%sProcBatchMin=%" PRIu64 " [us] | %sProcBatchMax=%" PRIu64
+				   " [us] | %sProcBatchAvg=%lf [us] | ",
+				   name, stat->proc_batch_min, name, stat->proc_batch_max, name,
+				   stat->proc_batch_avg);
+		*buffer += written;
+		*length -= written;
+	}
+
 	if (config_have_rx_timestamp() && app_config.classes[frame_type].xdp_enabled) {
 		written = snprintf(*buffer, *length,
 				   "%sRxMin=%" PRIu64 " [us] | %sRxMax=%" PRIu64

--- a/src/logviamqtt.c
+++ b/src/logviamqtt.c
@@ -76,48 +76,55 @@ static void log_via_mqtt_add_traffic_class(struct mosquitto *mosq, const char *m
 	p += written;
 	stat_message_length -= written;
 
-	written = snprintf(p, stat_message_length,
-			   ",\n\t\t\"%s\" : \n\t\t{\n"
-			   "\t\t\t\"TCName\" : \"%s\",\n"
-			   "\t\t\t\"FramesSent\" : %" PRIu64 ",\n"
-			   "\t\t\t\"FramesReceived\" : %" PRIu64 ",\n"
-			   "\t\t\t\"RoundTripTimeMin\" : %" PRIu64 ",\n"
-			   "\t\t\t\"RoundTripMax\" : %" PRIu64 ",\n"
-			   "\t\t\t\"RoundTripAv\" : %lf,\n"
-			   "\t\t\t\"OnewayMin\" : %" PRIu64 ",\n"
-			   "\t\t\t\"OnewayMax\" : %" PRIu64 ",\n"
-			   "\t\t\t\"OnewayAv\" : %lf,\n"
-			   "\t\t\t\"RxMin\" : %" PRIu64 ",\n"
-			   "\t\t\t\"RxMax\" : %" PRIu64 ",\n"
-			   "\t\t\t\"RxAv\" : %lf,\n"
-			   "\t\t\t\"RxHw2XdpMin\" : %" PRIu64 ",\n"
-			   "\t\t\t\"RxHw2XdpMax\" : %" PRIu64 ",\n"
-			   "\t\t\t\"RxHw2XdpAv\" : %lf,\n"
-			   "\t\t\t\"RxXdp2AppMin\" : %" PRIu64 ",\n"
-			   "\t\t\t\"RxXdp2AppMax\" : %" PRIu64 ",\n"
-			   "\t\t\t\"RxXdp2AppAv\" : %lf,\n"
-			   "\t\t\t\"RxWorkloadMin\" : %" PRIu64 ",\n"
-			   "\t\t\t\"RxWorkloadMax\" : %" PRIu64 ",\n"
-			   "\t\t\t\"RxWorkloadAv\" : %lf,\n"
-			   "\t\t\t\"TxMin\" : %" PRIu64 ",\n"
-			   "\t\t\t\"TxMax\" : %" PRIu64 ",\n"
-			   "\t\t\t\"TxAv\" : %lf,\n"
-			   "\t\t\t\"TxHwTimestampMissing\" : %" PRIu64 ",\n"
-			   "\t\t\t\"OutofOrderErrors\" : %" PRIu64 ",\n"
-			   "\t\t\t\"FrameIdErrors\" : %" PRIu64 ",\n"
-			   "\t\t\t\"PayloadErrors\" : %" PRIu64 ",\n"
-			   "\t\t\t\"RoundTripOutliers\" : %" PRIu64 ",\n"
-			   "\t\t\t\"OnewayOutliers\" : %" PRIu64 "\n\t\t}",
-			   "stats", name, stat->frames_sent, stat->frames_received,
-			   stat->round_trip_min, stat->round_trip_max, stat->round_trip_avg,
-			   stat->oneway_min, stat->oneway_max, stat->oneway_avg, stat->rx_min,
-			   stat->rx_max, stat->rx_avg, stat->rx_hw2xdp_min, stat->rx_hw2xdp_max,
-			   stat->rx_hw2xdp_avg, stat->rx_xdp2app_min, stat->rx_xdp2app_max,
-			   stat->rx_xdp2app_avg, stat->rx_workload_min, stat->rx_workload_max,
-			   stat->rx_workload_avg, stat->tx_min, stat->tx_max, stat->tx_avg,
-			   stat->tx_hw_timestamp_missing, stat->out_of_order_errors,
-			   stat->frame_id_errors, stat->payload_errors, stat->round_trip_outliers,
-			   stat->oneway_outliers);
+	written = snprintf(
+		p, stat_message_length,
+		",\n\t\t\"%s\" : \n\t\t{\n"
+		"\t\t\t\"TCName\" : \"%s\",\n"
+		"\t\t\t\"FramesSent\" : %" PRIu64 ",\n"
+		"\t\t\t\"FramesReceived\" : %" PRIu64 ",\n"
+		"\t\t\t\"RoundTripTimeMin\" : %" PRIu64 ",\n"
+		"\t\t\t\"RoundTripMax\" : %" PRIu64 ",\n"
+		"\t\t\t\"RoundTripAv\" : %lf,\n"
+		"\t\t\t\"OnewayMin\" : %" PRIu64 ",\n"
+		"\t\t\t\"OnewayMax\" : %" PRIu64 ",\n"
+		"\t\t\t\"OnewayAv\" : %lf,\n"
+		"\t\t\t\"ProcFirstMin\" : %" PRIu64 ",\n"
+		"\t\t\t\"ProcFirstMax\" : %" PRIu64 ",\n"
+		"\t\t\t\"ProcFirstAv\" : %lf,\n"
+		"\t\t\t\"ProcBatchMin\" : %" PRIu64 ",\n"
+		"\t\t\t\"ProcBatchMax\" : %" PRIu64 ",\n"
+		"\t\t\t\"ProcBatchAv\" : %lf,\n"
+		"\t\t\t\"RxMin\" : %" PRIu64 ",\n"
+		"\t\t\t\"RxMax\" : %" PRIu64 ",\n"
+		"\t\t\t\"RxAv\" : %lf,\n"
+		"\t\t\t\"RxHw2XdpMin\" : %" PRIu64 ",\n"
+		"\t\t\t\"RxHw2XdpMax\" : %" PRIu64 ",\n"
+		"\t\t\t\"RxHw2XdpAv\" : %lf,\n"
+		"\t\t\t\"RxXdp2AppMin\" : %" PRIu64 ",\n"
+		"\t\t\t\"RxXdp2AppMax\" : %" PRIu64 ",\n"
+		"\t\t\t\"RxXdp2AppAv\" : %lf,\n"
+		"\t\t\t\"RxWorkloadMin\" : %" PRIu64 ",\n"
+		"\t\t\t\"RxWorkloadMax\" : %" PRIu64 ",\n"
+		"\t\t\t\"RxWorkloadAv\" : %lf,\n"
+		"\t\t\t\"TxMin\" : %" PRIu64 ",\n"
+		"\t\t\t\"TxMax\" : %" PRIu64 ",\n"
+		"\t\t\t\"TxAv\" : %lf,\n"
+		"\t\t\t\"TxHwTimestampMissing\" : %" PRIu64 ",\n"
+		"\t\t\t\"OutofOrderErrors\" : %" PRIu64 ",\n"
+		"\t\t\t\"FrameIdErrors\" : %" PRIu64 ",\n"
+		"\t\t\t\"PayloadErrors\" : %" PRIu64 ",\n"
+		"\t\t\t\"RoundTripOutliers\" : %" PRIu64 ",\n"
+		"\t\t\t\"OnewayOutliers\" : %" PRIu64 "\n\t\t}",
+		"stats", name, stat->frames_sent, stat->frames_received, stat->round_trip_min,
+		stat->round_trip_max, stat->round_trip_avg, stat->oneway_min, stat->oneway_max,
+		stat->oneway_avg, stat->proc_first_min, stat->proc_first_max, stat->proc_first_avg,
+		stat->proc_batch_min, stat->proc_batch_max, stat->proc_batch_avg, stat->rx_min,
+		stat->rx_max, stat->rx_avg, stat->rx_hw2xdp_min, stat->rx_hw2xdp_max,
+		stat->rx_hw2xdp_avg, stat->rx_xdp2app_min, stat->rx_xdp2app_max,
+		stat->rx_xdp2app_avg, stat->rx_workload_min, stat->rx_workload_max,
+		stat->rx_workload_avg, stat->tx_min, stat->tx_max, stat->tx_avg,
+		stat->tx_hw_timestamp_missing, stat->out_of_order_errors, stat->frame_id_errors,
+		stat->payload_errors, stat->round_trip_outliers, stat->oneway_outliers);
 
 	p += written;
 	stat_message_length -= written;

--- a/src/rta_thread.c
+++ b/src/rta_thread.c
@@ -299,8 +299,8 @@ static void *rta_xdp_tx_thread_routine(void *data)
 	int ret;
 
 	xsk = thread_context->xsk;
-	xsk->rtt = &round_trip_contexts[RTA_FRAME_TYPE];
-	xsk->tx_hw_ts_seq_lagged = 0;
+	xsk->tx_hwts.rtt = &round_trip_contexts[RTA_FRAME_TYPE];
+	xsk->tx_hwts.frames_per_cycle = rta_config->num_frames_per_cycle;
 
 	ret = get_interface_mac_address(rta_config->interface, source, ETH_ALEN);
 	if (ret < 0) {
@@ -401,7 +401,7 @@ static void *rta_xdp_tx_thread_routine(void *data)
 				 * This is one cycle later than SW timestamp tracked
 				 * using sequence_counter
 				 */
-				xsk->tx_hw_ts_seq_lagged = sequence_counter;
+				xsk->tx_hwts.seq_lagged = sequence_counter;
 			}
 #endif
 

--- a/src/rtc_thread.c
+++ b/src/rtc_thread.c
@@ -315,8 +315,8 @@ static void *rtc_xdp_tx_thread_routine(void *data)
 	int ret;
 
 	xsk = thread_context->xsk;
-	xsk->rtt = &round_trip_contexts[RTC_FRAME_TYPE];
-	xsk->tx_hw_ts_seq_lagged = 0;
+	xsk->tx_hwts.rtt = &round_trip_contexts[RTC_FRAME_TYPE];
+	xsk->tx_hwts.frames_per_cycle = rtc_config->num_frames_per_cycle;
 
 	ret = get_interface_mac_address(rtc_config->interface, source, ETH_ALEN);
 	if (ret < 0) {
@@ -437,7 +437,7 @@ static void *rtc_xdp_tx_thread_routine(void *data)
 				 * This is one cycle later than SW timestamp tracked
 				 * using sequence_counter
 				 */
-				xsk->tx_hw_ts_seq_lagged = sequence_counter;
+				xsk->tx_hwts.seq_lagged = sequence_counter;
 			}
 #endif
 

--- a/src/stat.h
+++ b/src/stat.h
@@ -72,6 +72,18 @@ struct statistics {
 	uint64_t oneway_outliers;
 	double oneway_sum;
 	double oneway_avg;
+	/* First-frame processing latency at Mirror (1st Rx HW to 1st Tx HW timestamp) */
+	uint64_t proc_first_min;
+	uint64_t proc_first_max;
+	uint64_t proc_first_count;
+	double proc_first_sum;
+	double proc_first_avg;
+	/* Batch processing latency at Mirror (1st Rx HW to Last Tx HW timestamp) */
+	uint64_t proc_batch_min;
+	uint64_t proc_batch_max;
+	uint64_t proc_batch_count;
+	double proc_batch_sum;
+	double proc_batch_avg;
 	/* Rx latency from NIC Rx Hw timestamp to user space timestamp */
 	uint64_t rx_min;
 	uint64_t rx_max;
@@ -106,6 +118,7 @@ struct statistics {
 struct rtt_entry {
 	uint64_t sw_ts;
 	uint64_t hw_ts;
+	uint64_t rx_hw_ts;
 };
 
 struct round_trip_context {
@@ -128,8 +141,13 @@ void stat_get_stats_per_period(struct statistics *stats, size_t len);
 void stat_frame_workload(enum stat_frame_type, uint64_t cycle_number, struct timespec start_ts);
 void stat_inc_workload_outlier(enum stat_frame_type frame_type);
 void stat_frame_sent_latency(enum stat_frame_type frame_type, uint64_t seq);
+void stat_proc_first_latency(enum stat_frame_type frame_type, uint64_t cycle_number,
+			     uint64_t tx_hw_timestamp);
+void stat_proc_batch_latency(enum stat_frame_type frame_type, uint64_t cycle_number,
+			     uint64_t last_tx_hw_timestamp);
 
 extern volatile sig_atomic_t reset_stats;
 extern struct round_trip_context round_trip_contexts[NUM_FRAME_TYPES];
+extern int log_stat_user_selected;
 
 #endif /* _STAT_H_ */

--- a/src/tsn_thread.c
+++ b/src/tsn_thread.c
@@ -346,8 +346,8 @@ static void *tsn_xdp_tx_thread_routine(void *data)
 	int ret;
 
 	xsk = thread_context->xsk;
-	xsk->rtt = &round_trip_contexts[thread_context->frame_type];
-	xsk->tx_hw_ts_seq_lagged = 0;
+	xsk->tx_hwts.rtt = &round_trip_contexts[thread_context->frame_type];
+	xsk->tx_hwts.frames_per_cycle = tsn_config->num_frames_per_cycle;
 
 	ret = get_interface_mac_address(tsn_config->interface, source, ETH_ALEN);
 	if (ret < 0) {
@@ -486,7 +486,7 @@ static void *tsn_xdp_tx_thread_routine(void *data)
 				 * This is one cycle later than SW timestamp tracked
 				 * using sequence_counter
 				 */
-				xsk->tx_hw_ts_seq_lagged = sequence_counter;
+				xsk->tx_hwts.seq_lagged = sequence_counter;
 			}
 #endif
 

--- a/src/xdp.h
+++ b/src/xdp.h
@@ -40,6 +40,17 @@ struct xsk_umem_info {
 	void *buffer;
 };
 
+struct xdp_tx_hwts {
+	/* Store HW timestamps from AF_XDP completion queue */
+	struct round_trip_context *rtt;
+	/* Sequence number for TX HW timestamp (available one cycle later) */
+	int64_t seq_lagged;
+	/* Counter for tracking TX HW timestamp completions in current cycle (max 2: first+last) */
+	uint32_t count;
+	/* Total number of frames per cycle (needed to identify last packet) */
+	uint32_t frames_per_cycle;
+};
+
 struct xdp_socket {
 	uint64_t outstanding_tx;
 	struct xsk_ring_cons rx;
@@ -47,10 +58,8 @@ struct xdp_socket {
 	struct xsk_umem_info umem;
 	struct xsk_socket *xsk;
 	struct xdp_program *prog;
-	/* TX timestamping: Store HW timestamps from AF_XDP completion queue */
-	struct round_trip_context *rtt;
-	/* Sequence number for TX HW timestamp (available one cycle later) */
-	int64_t tx_hw_ts_seq_lagged;
+	/* TX hardware timestamping context */
+	struct xdp_tx_hwts tx_hwts;
 	int fd;
 	bool busy_poll_mode;
 	bool tx_time_mode;

--- a/tests/busypolling_1ms_rtworkload/mirror_vid100_cml.yaml
+++ b/tests/busypolling_1ms_rtworkload/mirror_vid100_cml.yaml
@@ -22,6 +22,7 @@ TsnHigh:
   TsnHighXdpZcMode: true
   TsnHighXdpWakeupMode: true
   TsnHighXdpBusyPollMode: true
+  TsnHighTxTimeStampEnabled: false
   TsnHighVid: 100
   TsnHighNumFramesPerCycle: 32
   TsnHighPayloadPattern: |

--- a/tests/busypolling_1ms_rtworkload/reference_vid100_cml.yaml
+++ b/tests/busypolling_1ms_rtworkload/reference_vid100_cml.yaml
@@ -22,6 +22,7 @@ TsnHigh:
   TsnHighXdpZcMode: true
   TsnHighXdpWakeupMode: true
   TsnHighXdpBusyPollMode: true
+  TsnHighTxTimeStampEnabled: false
   TsnHighVid: 100
   TsnHighNumFramesPerCycle: 32
   TsnHighPayloadPattern: |


### PR DESCRIPTION
This commit adds two new processing latency metrics for Mirror mode:

- ProcFirst: Latency from the first RX hardware timestamp to the first TX hardware timestamp (first-frame processing latency per cycle).
- ProcBatch: Latency from the first RX hardware timestamp to the last TX hardware timestamp (batch processing latency per cycle).

These metrics are automatically enabled when Mirror mode is built with both XDP and hardware timestamping enabled for RX and TX.

Usage example:
  Build with:
    cmake -DCMAKE_BUILD_TYPE=Release \
          -DWITH_MQTT=TRUE -DRX_TIMESTAMP=TRUE -DTX_TIMESTAMP=TRUE ..
  In the YAML config, enable per-class TX HW timestamping with:
    <Class>TxTimeStampEnabled: true

Example Mirror log output (3 TsnHigh packets per cycle):
  # 1st RX HW to 1st TX HW timestamp
  TsnHighProcFirstMin=999 [us]
  TsnHighProcFirstMax=1001 [us]
  TsnHighProcFirstAvg=999.198684 [us]

  # 1st RX HW to 3rd TX HW timestamp
  TsnHighProcBatchMin=1002 [us]
  TsnHighProcBatchMax=1003 [us]
  TsnHighProcBatchAvg=1002.000087 [us]