### PR TITLE
stat: Add outlier tracking for processing latency

### DIFF
--- a/Documentation/processing_latency.rst
+++ b/Documentation/processing_latency.rst
@@ -202,13 +202,15 @@ per cycle):
 .. code-block:: text
 
    # Processing Latency Metrics
-   TsnHighProcFirstMin=999 [us]
+   TsnHighProcFirstMin=982 [us]
    TsnHighProcFirstMax=1001 [us]
-   TsnHighProcFirstAvg=999.198684 [us]
+   TsnHighProcFirstAvg=998.476523 [us]
+   TsnHighProcFirstOutliers=1
 
-   TsnHighProcBatchMin=1002 [us]
+   TsnHighProcBatchMin=983 [us]
    TsnHighProcBatchMax=1003 [us]
-   TsnHighProcBatchAvg=1002.000087 [us]
+   TsnHighProcBatchAvg=1000.237762 [us]
+   TsnHighProcBatchOutliers=739
 
 Additional Monitoring Points
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/Documentation/statistics.rst
+++ b/Documentation/statistics.rst
@@ -56,9 +56,17 @@ The following table shows all gathered statistics. All statistics are collected 
      - Latency from the first RX hardware timestamp to the last TX hardware timestamp (batch
        processing latency per cycle). See :ref:`Processing Latency <ProcessingLatency>` for detailed information.
 
+   * - ProcBatchOutliers
+     - Is incremented if a ProcBatch latency is greater than cycle time. This usually indicates some
+       real time issue (e.g., kernel, driver, hardware, ...). Should be zero.
+
    * - ProcFirst[Min,Max,Av] [us]
      - Latency from the first RX hardware timestamp to the first TX hardware timestamp (first-frame
        processing latency per cycle). See :ref:`Processing Latency <ProcessingLatency>` for detailed information.
+
+   * - ProcFirstOutliers
+     - Is incremented if a ProcFirst latency is greater than cycle time. This usually indicates some
+       real time issue (e.g., kernel, driver, hardware, ...). Should be zero.
 
    * - RoundTrip[Min,Max,Av] [us]
      - Round trip delay measures the time from reference to mirror and back. The delay is calculated

--- a/src/log.c
+++ b/src/log.c
@@ -130,9 +130,10 @@ static void log_add_traffic_class(const char *name, enum stat_frame_type frame_t
 	    app_config.classes[frame_type].xdp_enabled && stat->proc_first_count > 0) {
 		written = snprintf(*buffer, *length,
 				   "%sProcFirstMin=%" PRIu64 " [us] | %sProcFirstMax=%" PRIu64
-				   " [us] | %sProcFirstAvg=%lf [us] | ",
+				   " [us] | %sProcFirstAvg=%lf [us] | "
+				   "%sProcFirstOutliers=%" PRIu64 " | ",
 				   name, stat->proc_first_min, name, stat->proc_first_max, name,
-				   stat->proc_first_avg);
+				   stat->proc_first_avg, name, stat->proc_first_outliers);
 		*buffer += written;
 		*length -= written;
 	}
@@ -141,9 +142,10 @@ static void log_add_traffic_class(const char *name, enum stat_frame_type frame_t
 	    app_config.classes[frame_type].xdp_enabled && stat->proc_batch_count > 0) {
 		written = snprintf(*buffer, *length,
 				   "%sProcBatchMin=%" PRIu64 " [us] | %sProcBatchMax=%" PRIu64
-				   " [us] | %sProcBatchAvg=%lf [us] | ",
+				   " [us] | %sProcBatchAvg=%lf [us] | "
+				   "%sProcBatchOutliers=%" PRIu64 " | ",
 				   name, stat->proc_batch_min, name, stat->proc_batch_max, name,
-				   stat->proc_batch_avg);
+				   stat->proc_batch_avg, name, stat->proc_batch_outliers);
 		*buffer += written;
 		*length -= written;
 	}

--- a/src/stat.h
+++ b/src/stat.h
@@ -76,12 +76,14 @@ struct statistics {
 	uint64_t proc_first_min;
 	uint64_t proc_first_max;
 	uint64_t proc_first_count;
+	uint64_t proc_first_outliers;
 	double proc_first_sum;
 	double proc_first_avg;
 	/* Batch processing latency at Mirror (1st Rx HW to Last Tx HW timestamp) */
 	uint64_t proc_batch_min;
 	uint64_t proc_batch_max;
 	uint64_t proc_batch_count;
+	uint64_t proc_batch_outliers;
 	double proc_batch_sum;
 	double proc_batch_avg;
 	/* Rx latency from NIC Rx Hw timestamp to user space timestamp */


### PR DESCRIPTION
Add proc_first_outliers and proc_batch_outliers fields to statistics structure to track when processing latency exceeds the configured cycle time.

This helps identify performance issues where frames processing takes longer than the cycle time, indicating potential system overload or scheduling problems.