### PR TITLE
build: Fix minimum libxdp version for AF_XDP TX timestamp support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ if (WITH_MQTT)
 endif()
 
 option(RX_TIMESTAMP "Enable RX timestamp support (requires libbpf >= 1.2)" OFF)
-option(TX_TIMESTAMP "Enable TX timestamp support (requires libxdp >= 1.4.1)" OFF)
+option(TX_TIMESTAMP "Enable TX timestamp support (requires libxdp >= 1.5.2)" OFF)
 
 if(RX_TIMESTAMP)
   pkg_check_modules(LIBBPF_REQUIRED_FOR_RX_TIMESTAMP libbpf>=1.2)
@@ -128,8 +128,8 @@ if(RX_TIMESTAMP)
 endif()
 
 if(TX_TIMESTAMP)
-  if(NOT ((${LIBXDP_VERSION} GREATER_EQUAL 1.4.1) AND (${HAVE_XDP_FLAGS_TX_HWTSTAMP})))
-    message(FATAL_ERROR "TX_TIMESTAMP requires libxdp >= 1.4.1 and kernel support for XDP_TXMD_FLAGS_TIMESTAMP")
+  if(NOT ((${LIBXDP_VERSION} GREATER_EQUAL 1.5.2) AND (${HAVE_XDP_FLAGS_TX_HWTSTAMP})))
+    message(FATAL_ERROR "TX_TIMESTAMP requires libxdp >= 1.5.2 and kernel support for XDP_TXMD_FLAGS_TIMESTAMP")
   endif()
 endif()
 
@@ -206,9 +206,9 @@ if ((${LIBXDP_VERSION} GREATER_EQUAL 1.5.0) AND (${HAVE_XDP_FLAGS_TX_TIME}))
 endif()
 
 #
-# Check for XDP and Tx HW Timestamp support. It requires: libxdp >= 1.4.1 and Linux v6.8.
+# Check for XDP and Tx HW Timestamp support. It requires: libxdp >= 1.5.2 and Linux v6.8.
 #
-if ((${LIBXDP_VERSION} GREATER_EQUAL 1.4.1) AND (${HAVE_XDP_FLAGS_TX_HWTSTAMP}))
+if ((${LIBXDP_VERSION} GREATER_EQUAL 1.5.2) AND (${HAVE_XDP_FLAGS_TX_HWTSTAMP}))
   message(STATUS "XDP and Tx HW Timestamp support available using libxdp version: ${LIBXDP_VERSION}")
 endif()
 

--- a/Documentation/processing_latency.rst
+++ b/Documentation/processing_latency.rst
@@ -162,7 +162,7 @@ The following table summarizes all dependencies:
      - Any version
    * - **libxdp**
      - Any version
-     - >= 1.4.1
+     - >= 1.5.2
    * - **NIC Driver Feature**
      - bpf_xdp_metadata_rx_timestamp()
      - XDP_TXMD_FLAGS_TIMESTAMP

--- a/src/config.c
+++ b/src/config.c
@@ -1558,7 +1558,7 @@ bool config_sanity_check(void)
 	     (app_config.classes[TSN_LOW_FRAME_TYPE].tx_hwtstamp_enabled &&
 	      app_config.classes[TSN_LOW_FRAME_TYPE].xdp_enabled))) {
 		fprintf(stderr, "XDP Tx HW Timestamp requires TX_TIMESTAMP build support!\n");
-		fprintf(stderr, "Rebuild with -DTX_TIMESTAMP=ON (requires libxdp >= v1.4.1 and "
+		fprintf(stderr, "Rebuild with -DTX_TIMESTAMP=ON (requires libxdp >= v1.5.2 and "
 				"Linux kernel >= v6.8).\n");
 		return false;
 	}


### PR DESCRIPTION
Update libxdp version requirement from 1.4.1 to 1.5.2 for AF_XDP TX timestamp support across CMakeLists.txt, documentation, and error messages.

This version includes two critical libxdp commits:
- 44b5e00692db ("libxdp: Add tx_metadata_len/xsk_umem__create_opts() to support AF_XDP Tx metadata")
- 7147047341d2 ("libxdp: Fix incorrect setsockopt xdp_umem_reg size")