### PR TITLE
stat: skip outlier detection for initial rx workload measurements

### DIFF
--- a/Documentation/workload.rst
+++ b/Documentation/workload.rst
@@ -67,7 +67,7 @@ The following options are used to configure a RX workload:
      - Execute workload immediately when threads spawn (true) or wait for network traffic (false)
 
    * - <Class>RxWorkloadSkipCount (Integer)
-     - Skip min/max statistics updates for the first N workload iterations
+     - Skip min/max statistics and outlier updates for the first N workload iterations
 
    * - <Class>RxWorkloadThreadCpu (Integer)
      - CPU core number to pin the workload thread to

--- a/src/stat.c
+++ b/src/stat.c
@@ -786,7 +786,8 @@ void stat_inc_workload_outlier(enum stat_frame_type frame_type)
 {
 	struct statistics *stat = &global_statistics[frame_type];
 
-	stat->rx_workload_outliers++;
+	if (stat->rx_workload_count > app_config.classes[frame_type].rx_workload_skip_count)
+		stat->rx_workload_outliers++;
 }
 
 static int append_jlog_u64(char **buffer, size_t *len, const char *stat, uint64_t value)


### PR DESCRIPTION
During the first <Class>RxWorkloadSkipCount rx workload measurements, min/max statistics are skipped. So it makes sense to skip outlier counting as well.