### PR TITLE
igc: Explicitly disable Energy Efficient Ethernet (EEE)

### DIFF
--- a/tests/lib/igc.sh
+++ b/tests/lib/igc.sh
@@ -28,6 +28,11 @@ igc_start() {
   # Increase the number of Rx and Tx queues in case of $num_cpus < 4.
   #
   ethtool -L "${interface}" combined 4
+
+  #
+  # Disable Energy Efficient Ethernet (EEE).
+  #
+  ethtool --set-eee "${interface}" eee off
 }
 
 #


### PR DESCRIPTION
Add explicit EEE disable command to IGC interface setup even though EEE is disabled by default. This ensures deterministic behavior regardless of:

- Hardware/firmware variations that might enable EEE.
- Driver updates that could change default behavior.
- System configurations that might override defaults.