### PR TITLE
tests/intel_kpi: Add i226 XDP 1ms test with asymmetric RX workload

### DIFF
--- a/tests/intel_kpi/i226_xdp_1ms_32x128b_57k/flow.sh
+++ b/tests/intel_kpi/i226_xdp_1ms_32x128b_57k/flow.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Copyright (C) 2026 Linutronix GmbH
+# Author Kurt Kanzenbach <kurt@linutronix.de>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Setup the Tx and Rx traffic flows for Intel i226 for KPI testing.
+#
+
+set -e
+
+source ../../lib/common.sh
+source ../../lib/igc.sh
+
+#
+# Command line arguments.
+#
+INTERFACE=$1
+CYCLETIME_NS=$2
+BASETIME=$3
+
+[ -z $INTERFACE ] && INTERFACE="enp3s0"                          # default: enp3s0
+[ -z $CYCLETIME_NS ] && CYCLETIME_NS="1000000"                   # default: 1ms
+[ -z $BASETIME ] && BASETIME=$(date '+%s000000000' -d '-30 sec') # default: now - 30s
+
+load_kernel_modules
+
+napi_defer_hard_irqs "${INTERFACE}" "${CYCLETIME_NS}"
+
+igc_start "${INTERFACE}"
+
+#
+# Split traffic between TSN High stream and everything else.
+#
+ENTRY1_NS="500000" # TSN High stream
+ENTRY2_NS="500000" # Everything else
+
+#
+# Tx Assignment with Qbv and full hardware offload.
+#
+# PCP 6 - Tx Q 1 - TSN High stream
+# PCP X - Tx Q 0 - Everything else
+#
+tc qdisc replace dev ${INTERFACE} handle 100 parent root taprio num_tc 2 \
+  map 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 \
+  queues 1@0 1@1 \
+  base-time ${BASETIME} \
+  sched-entry S 0x02 ${ENTRY1_NS} \
+  sched-entry S 0x03 ${ENTRY2_NS} \
+  flags 0x02
+
+#
+# Rx Queues Assignment.
+#
+# PCP 6 - Rx Q 1 - TSN High stream
+# PCP X - Rx Q 0 - Everything else
+#
+RXQUEUES=(0 1 0 0 0 0 0 0 0 0)
+igc_rx_queues_assign "${INTERFACE}" RXQUEUES
+
+igc_end "${INTERFACE}"
+
+setup_irqs "${INTERFACE}"
+
+exit 0

--- a/tests/intel_kpi/i226_xdp_1ms_32x128b_57k/mirror.sh
+++ b/tests/intel_kpi/i226_xdp_1ms_32x128b_57k/mirror.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Copyright (C) 2026 Linutronix GmbH
+# Author Kurt Kanzenbach <kurt@linutronix.de>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+set -e
+
+cd "$(dirname "$0")"
+
+# Start PTP
+../../../scripts/ptp.sh enp3s0
+sleep 30
+
+# Configure flow
+./flow.sh enp3s0
+sleep 30
+
+# Start one instance of mirror application
+cp ../../../build/xdp_kern_*.o .
+../../../build/mirror -c mirror.yaml >mirror.log &
+
+exit 0

--- a/tests/intel_kpi/i226_xdp_1ms_32x128b_57k/mirror.yaml
+++ b/tests/intel_kpi/i226_xdp_1ms_32x128b_57k/mirror.yaml
@@ -1,0 +1,65 @@
+---
+#
+# Copyright (C) 2026 Linutronix GmbH
+# Author Kurt Kanzenbach <kurt@linutronix.de>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Sample mirror YAML configuration file for Intel platforms with i226 NIC(s).
+#
+Application:
+  ApplicationClockId: CLOCK_TAI
+  # ApplicationBaseStartTimeNS: 0
+  ApplicationBaseCycleTimeNS: 1ms
+  ApplicationTxBaseOffsetNS: 700us
+  ApplicationRxBaseOffsetNS: 300us
+  ApplicationXdpProgram: xdp_kern_profinet_vid100.o
+TsnHigh:
+  TsnHighEnabled: true
+  TsnHighXdpEnabled: true
+  TsnHighXdpSkbMode: false
+  TsnHighXdpZcMode: true
+  TsnHighXdpWakeupMode: true
+  TsnHighXdpBusyPollMode: true
+  TsnHighTxTimeStampEnabled: false
+  TsnHighVid: 100
+  TsnHighNumFramesPerCycle: 32
+  TsnHighPayloadPattern: |
+    TsnHighPayloadPattern
+  TsnHighFrameLength: 128
+  TsnHighRxQueue: 1
+  TsnHighTxQueue: 1
+  TsnHighSocketPriority: 7
+  TsnHighTxThreadPriority: 98
+  TsnHighRxThreadPriority: 98
+  TsnHighTxThreadCpu: 1
+  TsnHighRxThreadCpu: 1
+  TsnHighInterface: enp3s0
+  TsnHighDestination: a8:74:1d:9d:36:14
+  TsnHighRxWorkloadEnabled: true
+  TsnHighRxWorkloadFile: ../../workloads/pointer_chasing/pointer_chasing.so
+  TsnHighRxWorkloadSetupFunction: ptr_chase_setup
+  TsnHighRxWorkloadSetupArguments: "0x4A4000 0x129000"
+  TsnHighRxWorkloadTeardownFunction: ptr_chase_teardown
+  TsnHighRxWorkloadFunction: run_ptr_chasing
+  TsnHighRxWorkloadPrewarm: false
+  TsnHighRxWorkloadSkipCount: 100
+  TsnHighRxWorkloadThreadCpu: 1
+  TsnHighRxWorkloadThreadPriority: 80
+Log:
+  LogThreadPriority: 1
+  LogThreadCpu: 0
+  LogFile: /var/log/mirror_vid100.log
+  LogLevel: Info
+LogMqtt:
+  LogMqtt: True
+  LogMqttThreadPriority: 10
+  LogMqttThreadCpu: 0
+  LogMqttBrokerIP: 127.0.0.1
+  LogMqttBrokerPort: 1883
+  LogMqttMeasurementName: mirror
+Debug:
+  DebugStopTraceOnOutlier: false
+  DebugStopTraceOnError: false
+  DebugMonitorMode: false
+  DebugMonitorDestination: 44:44:44:44:44:44

--- a/tests/intel_kpi/i226_xdp_1ms_32x128b_57k/ref.sh
+++ b/tests/intel_kpi/i226_xdp_1ms_32x128b_57k/ref.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Copyright (C) 2026 Linutronix GmbH
+# Author Kurt Kanzenbach <kurt@linutronix.de>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+set -e
+
+cd "$(dirname "$0")"
+
+# Start PTP
+../../../scripts/ptp.sh enp3s0
+sleep 30
+
+# Configure flow
+./flow.sh enp3s0
+sleep 30
+
+# Start one instance of reference application
+cp ../../../build/xdp_kern_*.o .
+../../../build/reference -c reference.yaml >ref.log &
+
+exit 0

--- a/tests/intel_kpi/i226_xdp_1ms_32x128b_57k/reference.yaml
+++ b/tests/intel_kpi/i226_xdp_1ms_32x128b_57k/reference.yaml
@@ -1,0 +1,56 @@
+---
+#
+# Copyright (C) 2026 Linutronix GmbH
+# Author Kurt Kanzenbach <kurt@linutronix.de>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Sample reference YAML configuration file for Intel platforms with i226 NIC(s).
+#
+Application:
+  ApplicationClockId: CLOCK_TAI
+  # ApplicationBaseStartTimeNS: 0
+  ApplicationBaseCycleTimeNS: 1ms
+  ApplicationTxBaseOffsetNS: 700us
+  ApplicationRxBaseOffsetNS: 300us
+  ApplicationXdpProgram: xdp_kern_profinet_vid100.o
+TsnHigh:
+  TsnHighEnabled: true
+  TsnHighXdpEnabled: true
+  TsnHighXdpSkbMode: false
+  TsnHighXdpZcMode: true
+  TsnHighXdpWakeupMode: true
+  TsnHighXdpBusyPollMode: true
+  TsnHighTxTimeStampEnabled: false
+  TsnHighVid: 100
+  TsnHighNumFramesPerCycle: 32
+  TsnHighPayloadPattern: |
+    TsnHighPayloadPattern
+  TsnHighFrameLength: 128
+  TsnHighRxQueue: 1
+  TsnHighTxQueue: 1
+  TsnHighSocketPriority: 7
+  TsnHighTxThreadPriority: 98
+  TsnHighRxThreadPriority: 98
+  TsnHighTxThreadCpu: 1
+  TsnHighRxThreadCpu: 1
+  TsnHighInterface: enp3s0
+  TsnHighDestination: a8:74:1d:9d:98:d8
+  TsnHighRxWorkloadEnabled: false
+Log:
+  LogThreadPriority: 1
+  LogThreadCpu: 0
+  LogFile: /var/log/reference_vid100.log
+  LogLevel: Info
+LogMqtt:
+  LogMqtt: true
+  LogMqttThreadPriority: 10
+  LogMqttThreadCpu: 0
+  LogMqttBrokerIP: 127.0.0.1
+  LogMqttBrokerPort: 1883
+  LogMqttMeasurementName: reference
+Debug:
+  DebugStopTraceOnOutlier: false
+  DebugStopTraceOnError: false
+  DebugMonitorMode: false
+  DebugMonitorDestination: 44:44:44:44:44:44


### PR DESCRIPTION
Add new test case based on the existing busypolling_1ms_rtworkload test configuration. This test targets Intel i226 NIC performance with XDP busy polling using 1ms cycle time, 32 frames of 128 bytes per cycle, and 57k instruction per control loop.

Difference from the source test:
- Disabled Reference's RX workload
- Enabled MQTT
- Set Mirror's TxRx and Rx workload threads to CPU1

More test cases will be added into intel_kpi folder in future.