### PR TITLE
stat: Fix rx latency averages using dedicated rx_count

### DIFF
--- a/src/stat.c
+++ b/src/stat.c
@@ -282,17 +282,19 @@ static bool stat_frame_received_common(struct statistics *stat, enum stat_frame_
 	stat->oneway_avg = stat->oneway_sum / (double)stat->oneway_count;
 
 	if (rx_hw2app_time != 0 && rx_hw2xdp_time != 0 && rx_xdp2app_time != 0) {
+		stat->rx_count++;
+
 		stat_update_min_max(rx_hw2app_time, &stat->rx_min, &stat->rx_max);
 		stat->rx_sum += rx_hw2app_time;
-		stat->rx_avg = stat->rx_sum / (double)stat->oneway_count;
+		stat->rx_avg = stat->rx_sum / (double)stat->rx_count;
 
 		stat_update_min_max(rx_hw2xdp_time, &stat->rx_hw2xdp_min, &stat->rx_hw2xdp_max);
 		stat->rx_hw2xdp_sum += rx_hw2xdp_time;
-		stat->rx_hw2xdp_avg = stat->rx_hw2xdp_sum / (double)stat->oneway_count;
+		stat->rx_hw2xdp_avg = stat->rx_hw2xdp_sum / (double)stat->rx_count;
 
 		stat_update_min_max(rx_xdp2app_time, &stat->rx_xdp2app_min, &stat->rx_xdp2app_max);
 		stat->rx_xdp2app_sum += rx_xdp2app_time;
-		stat->rx_xdp2app_avg = stat->rx_xdp2app_sum / (double)stat->oneway_count;
+		stat->rx_xdp2app_avg = stat->rx_xdp2app_sum / (double)stat->rx_count;
 	}
 
 	stat->frames_received++;

--- a/src/stat.h
+++ b/src/stat.h
@@ -101,6 +101,7 @@ struct statistics {
 	/* Rx latency from NIC Rx Hw timestamp to user space timestamp */
 	uint64_t rx_min;
 	uint64_t rx_max;
+	uint64_t rx_count;
 	double rx_sum;
 	double rx_avg;
 	/* Rx latency from NIC Rx Hw timestamp to Xdp prog timestamp */


### PR DESCRIPTION
Before this fix, rx_hw2app, rx_hw2xdp and rx_xdp2app averages were divided by oneway_count instead of the number of frames that actually carried rx hardware timestamps. Because oneway_count is typically much larger, the computed averages were smaller than the recorded minimums.

Introduce rx_count, incremented only when all three rx hardware timestamps are valid, and use it as the divisor for all rx averages.