### PR TITLE
xdp: Fix TX HW timestamp correlation by frame sequence

### DIFF
--- a/src/dcp_thread.c
+++ b/src/dcp_thread.c
@@ -156,8 +156,8 @@ static void dcp_gen_and_send_frames(struct thread_context *thread_context, int s
 	len = dcp_send_messages(thread_context, socket_fd, destination,
 				thread_context->tx_frame_data, dcp_config->num_frames_per_cycle);
 
-	for (i = 0; i < len; i++)
-		stat_frame_sent(DCP_FRAME_TYPE, sequence_counter_begin + i);
+	if (len > 0)
+		stat_frames_sent_batch(DCP_FRAME_TYPE, sequence_counter_begin, len);
 }
 
 static void *dcp_tx_thread_routine(void *data)
@@ -481,6 +481,8 @@ int dcp_threads_create(struct thread_context *thread_context)
 		}
 	}
 
+	thread_context->meta_data_offset = get_meta_data_offset(DCP_FRAME_TYPE, SECURITY_MODE_NONE);
+
 	ret = create_rt_thread(&thread_context->tx_task_id, dcp_config->tx_thread_priority,
 			       dcp_config->tx_thread_cpu, dcp_tx_thread_routine, thread_context,
 			       "DcpTxThread");
@@ -507,8 +509,6 @@ int dcp_threads_create(struct thread_context *thread_context)
 		fprintf(stderr, "Failed to create Dcp Rx Thread!\n");
 		goto err_thread_rx;
 	}
-
-	thread_context->meta_data_offset = get_meta_data_offset(DCP_FRAME_TYPE, SECURITY_MODE_NONE);
 
 out:
 	return 0;

--- a/src/layer2_thread.c
+++ b/src/layer2_thread.c
@@ -179,8 +179,8 @@ static int generic_l2_gen_and_send_frames(struct thread_context *thread_context,
 				       thread_context->tx_frame_data, num_frames_per_cycle,
 				       duration);
 
-	for (i = 0; i < len; i++)
-		stat_frame_sent(GENERICL2_FRAME_TYPE, sequence_counter_begin + i);
+	if (len > 0)
+		stat_frames_sent_batch(GENERICL2_FRAME_TYPE, sequence_counter_begin, len);
 
 	return len;
 }
@@ -333,6 +333,7 @@ static void *generic_l2_xdp_tx_thread_routine(void *data)
 	xsk = thread_context->xsk;
 	xsk->tx_hwts.rtt = &round_trip_contexts[GENERICL2_FRAME_TYPE];
 	xsk->tx_hwts.frames_per_cycle = l2_config->num_frames_per_cycle;
+	xsk->tx_hwts.meta_data_offset = thread_context->meta_data_offset;
 
 	ret = get_interface_mac_address(l2_config->interface, source, ETH_ALEN);
 	if (ret < 0) {
@@ -387,7 +388,6 @@ static void *generic_l2_xdp_tx_thread_routine(void *data)
 			sequence_counter += num_frames;
 		} else {
 			unsigned int received;
-			uint64_t i;
 
 			pthread_mutex_lock(&thread_context->xdp_data_mutex);
 
@@ -403,36 +403,13 @@ static void *generic_l2_xdp_tx_thread_routine(void *data)
 
 			xsk_ring_prod__submit(&xsk->tx, received);
 
-			if (received > 0) {
-				if (l2_config->tx_hwtstamp_enabled) {
-					/*
-					 * Once-per-cycle: record TX SW timestamp for the first
-					 * packet in this cycle and count all frames
-					 */
-					stat_frames_sent_batch(GENERICL2_FRAME_TYPE,
-							       sequence_counter, received);
-				} else {
-					for (i = sequence_counter; i < sequence_counter + received;
-					     ++i)
-						stat_frame_sent(GENERICL2_FRAME_TYPE, i);
-				}
-			}
+			if (received > 0)
+				stat_frames_sent_batch(GENERICL2_FRAME_TYPE, sequence_counter,
+						       received);
 
 			xsk->outstanding_tx += received;
 			thread_context->received_frames = 0;
 			xdp_complete_tx(xsk);
-
-#ifdef TX_TIMESTAMP
-			if (received > 0 && l2_config->tx_hwtstamp_enabled) {
-				/*
-				 * TX HW timestamp becomes available in the next cycle
-				 * after the packet is transmitted.
-				 * This is one cycle later than SW timestamp tracked
-				 * using sequence_counter
-				 */
-				xsk->tx_hwts.seq_lagged = sequence_counter;
-			}
-#endif
 
 			pthread_mutex_unlock(&thread_context->xdp_data_mutex);
 		}
@@ -743,6 +720,9 @@ struct thread_context *generic_l2_threads_create(void)
 		}
 	}
 
+	thread_context->meta_data_offset =
+		get_meta_data_offset(GENERICL2_FRAME_TYPE, SECURITY_MODE_NONE);
+
 	ret = create_rt_thread(&thread_context->tx_task_id, l2_config->tx_thread_priority,
 			       l2_config->tx_thread_cpu,
 			       l2_config->xdp_enabled ? generic_l2_xdp_tx_thread_routine
@@ -769,9 +749,6 @@ struct thread_context *generic_l2_threads_create(void)
 		fprintf(stderr, "Failed to create L2 Workload context!\n");
 		goto err_thread_wl;
 	}
-
-	thread_context->meta_data_offset =
-		get_meta_data_offset(GENERICL2_FRAME_TYPE, SECURITY_MODE_NONE);
 
 out:
 	return thread_context;

--- a/src/lldp_thread.c
+++ b/src/lldp_thread.c
@@ -162,8 +162,8 @@ static int lldp_gen_and_send_frames(struct thread_context *thread_context, int s
 	len = lldp_send_messages(thread_context, socket_fd, destination,
 				 thread_context->tx_frame_data, lldp_config->num_frames_per_cycle);
 
-	for (i = 0; i < len; i++)
-		stat_frame_sent(LLDP_FRAME_TYPE, sequence_counter_begin + i);
+	if (len > 0)
+		stat_frames_sent_batch(LLDP_FRAME_TYPE, sequence_counter_begin, len);
 
 	return len;
 }
@@ -493,6 +493,9 @@ int lldp_threads_create(struct thread_context *thread_context)
 		}
 	}
 
+	thread_context->meta_data_offset =
+		get_meta_data_offset(LLDP_FRAME_TYPE, SECURITY_MODE_NONE);
+
 	ret = create_rt_thread(&thread_context->tx_task_id, lldp_config->tx_thread_priority,
 			       lldp_config->tx_thread_cpu, lldp_tx_thread_routine, thread_context,
 			       "LldpTxThread");
@@ -519,9 +522,6 @@ int lldp_threads_create(struct thread_context *thread_context)
 		fprintf(stderr, "Failed to create Lldp Rx Thread!\n");
 		goto err_thread_rx;
 	}
-
-	thread_context->meta_data_offset =
-		get_meta_data_offset(LLDP_FRAME_TYPE, SECURITY_MODE_NONE);
 
 out:
 	ret = 0;

--- a/src/rta_thread.c
+++ b/src/rta_thread.c
@@ -143,8 +143,8 @@ static int rta_gen_and_send_frames(struct thread_context *thread_context, int so
 	len = rta_send_messages(thread_context, socket_fd, destination,
 				thread_context->tx_frame_data, rta_config->num_frames_per_cycle);
 
-	for (i = 0; i < len; i++)
-		stat_frame_sent(RTA_FRAME_TYPE, sequence_counter_begin + i);
+	if (len > 0)
+		stat_frames_sent_batch(RTA_FRAME_TYPE, sequence_counter_begin, len);
 
 	return len;
 }
@@ -301,6 +301,7 @@ static void *rta_xdp_tx_thread_routine(void *data)
 	xsk = thread_context->xsk;
 	xsk->tx_hwts.rtt = &round_trip_contexts[RTA_FRAME_TYPE];
 	xsk->tx_hwts.frames_per_cycle = rta_config->num_frames_per_cycle;
+	xsk->tx_hwts.meta_data_offset = thread_context->meta_data_offset;
 
 	ret = get_interface_mac_address(rta_config->interface, source, ETH_ALEN);
 	if (ret < 0) {
@@ -353,7 +354,6 @@ static void *rta_xdp_tx_thread_routine(void *data)
 			}
 		} else {
 			unsigned int received;
-			uint64_t i;
 
 			pthread_mutex_lock(&thread_context->xdp_data_mutex);
 
@@ -369,36 +369,12 @@ static void *rta_xdp_tx_thread_routine(void *data)
 
 			xsk_ring_prod__submit(&xsk->tx, received);
 
-			if (received > 0) {
-				if (rta_config->tx_hwtstamp_enabled) {
-					/*
-					 * Once-per-cycle: record TX SW timestamp for the first
-					 * packet in this cycle and count all frames
-					 */
-					stat_frames_sent_batch(RTA_FRAME_TYPE, sequence_counter,
-							       received);
-				} else {
-					for (i = sequence_counter; i < sequence_counter + received;
-					     ++i)
-						stat_frame_sent(RTA_FRAME_TYPE, i);
-				}
-			}
+			if (received > 0)
+				stat_frames_sent_batch(RTA_FRAME_TYPE, sequence_counter, received);
 
 			xsk->outstanding_tx += received;
 			thread_context->received_frames = 0;
 			xdp_complete_tx(xsk);
-
-#ifdef TX_TIMESTAMP
-			if (received > 0 && rta_config->tx_hwtstamp_enabled) {
-				/*
-				 * TX HW timestamp becomes available in the next cycle
-				 * after the packet is transmitted.
-				 * This is one cycle later than SW timestamp tracked
-				 * using sequence_counter
-				 */
-				xsk->tx_hwts.seq_lagged = sequence_counter;
-			}
-#endif
 
 			pthread_mutex_unlock(&thread_context->xdp_data_mutex);
 		}
@@ -673,6 +649,9 @@ int rta_threads_create(struct thread_context *thread_context)
 		thread_context->rx_security_context = NULL;
 	}
 
+	thread_context->meta_data_offset =
+		get_meta_data_offset(RTA_FRAME_TYPE, rta_config->security_mode);
+
 	ret = create_rt_thread(&thread_context->tx_task_id, rta_config->tx_thread_priority,
 			       rta_config->tx_thread_cpu,
 			       rta_config->xdp_enabled ? rta_xdp_tx_thread_routine
@@ -703,9 +682,6 @@ int rta_threads_create(struct thread_context *thread_context)
 		fprintf(stderr, "Failed to create Rta Rx Thread!\n");
 		goto err_thread_rx;
 	}
-
-	thread_context->meta_data_offset =
-		get_meta_data_offset(RTA_FRAME_TYPE, rta_config->security_mode);
 
 out:
 	return 0;

--- a/src/rtc_thread.c
+++ b/src/rtc_thread.c
@@ -145,8 +145,8 @@ static int rtc_gen_and_send_frames(struct thread_context *thread_context, int so
 	len = rtc_send_messages(thread_context, socket_fd, destination,
 				thread_context->tx_frame_data, rtc_config->num_frames_per_cycle);
 
-	for (i = 0; i < len; i++)
-		stat_frame_sent(RTC_FRAME_TYPE, sequence_counter_begin + i);
+	if (len > 0)
+		stat_frames_sent_batch(RTC_FRAME_TYPE, sequence_counter_begin, len);
 
 	return len;
 }
@@ -320,6 +320,7 @@ static void *rtc_xdp_tx_thread_routine(void *data)
 	xsk = thread_context->xsk;
 	xsk->tx_hwts.rtt = &round_trip_contexts[RTC_FRAME_TYPE];
 	xsk->tx_hwts.frames_per_cycle = rtc_config->num_frames_per_cycle;
+	xsk->tx_hwts.meta_data_offset = thread_context->meta_data_offset;
 
 	ret = get_interface_mac_address(rtc_config->interface, source, ETH_ALEN);
 	if (ret < 0) {
@@ -394,7 +395,6 @@ static void *rtc_xdp_tx_thread_routine(void *data)
 			sequence_counter += num_frames;
 		} else {
 			unsigned int received;
-			uint64_t i;
 
 			pthread_mutex_lock(&thread_context->xdp_data_mutex);
 
@@ -410,36 +410,12 @@ static void *rtc_xdp_tx_thread_routine(void *data)
 
 			xsk_ring_prod__submit(&xsk->tx, received);
 
-			if (received > 0) {
-				if (rtc_config->tx_hwtstamp_enabled) {
-					/*
-					 * Once-per-cycle: record TX SW timestamp for the first
-					 * packet in this cycle and count all frames
-					 */
-					stat_frames_sent_batch(RTC_FRAME_TYPE, sequence_counter,
-							       received);
-				} else {
-					for (i = sequence_counter; i < sequence_counter + received;
-					     ++i)
-						stat_frame_sent(RTC_FRAME_TYPE, i);
-				}
-			}
+			if (received > 0)
+				stat_frames_sent_batch(RTC_FRAME_TYPE, sequence_counter, received);
 
 			xsk->outstanding_tx += received;
 			thread_context->received_frames = 0;
 			xdp_complete_tx(xsk);
-
-#ifdef TX_TIMESTAMP
-			if (received > 0 && rtc_config->tx_hwtstamp_enabled) {
-				/*
-				 * TX HW timestamp becomes available in the next cycle
-				 * after the packet is transmitted.
-				 * This is one cycle later than SW timestamp tracked
-				 * using sequence_counter
-				 */
-				xsk->tx_hwts.seq_lagged = sequence_counter;
-			}
-#endif
 
 			pthread_mutex_unlock(&thread_context->xdp_data_mutex);
 		}
@@ -671,6 +647,9 @@ int rtc_threads_create(struct thread_context *thread_context)
 		thread_context->rx_security_context = NULL;
 	}
 
+	thread_context->meta_data_offset =
+		get_meta_data_offset(RTC_FRAME_TYPE, rtc_config->security_mode);
+
 	ret = create_rt_thread(&thread_context->tx_task_id, rtc_config->tx_thread_priority,
 			       rtc_config->tx_thread_cpu,
 			       rtc_config->xdp_enabled ? rtc_xdp_tx_thread_routine
@@ -697,9 +676,6 @@ int rtc_threads_create(struct thread_context *thread_context)
 		fprintf(stderr, "Failed to create Rtc Workload context!\n");
 		goto err_thread_wl;
 	}
-
-	thread_context->meta_data_offset =
-		get_meta_data_offset(RTC_FRAME_TYPE, rtc_config->security_mode);
 
 out:
 	return 0;

--- a/src/stat.c
+++ b/src/stat.c
@@ -455,7 +455,6 @@ void stat_frames_sent_batch(enum stat_frame_type frame_type, uint64_t cycle_numb
 {
 	struct round_trip_context *rtt = &round_trip_contexts[frame_type];
 	struct statistics *stat = &global_statistics[frame_type];
-	size_t idx = cycle_number % rtt->backlog_len;
 	struct timespec tx_time = {};
 
 	if (frame_count == 1) {
@@ -469,9 +468,32 @@ void stat_frames_sent_batch(enum stat_frame_type frame_type, uint64_t cycle_numb
 	if ((log_stat_user_selected == LOG_REFERENCE ||
 	     log_stat_user_selected == LOG_TX_TIMESTAMPS) &&
 	    rtt->backlog) {
-		/* Record Tx SW timestamp for the first frame in the cycle */
+		uint64_t end = cycle_number + frame_count;
+		uint64_t c;
+
 		app_clock_get(&tx_time);
-		rtt->backlog[idx].sw_ts = ts_to_ns(&tx_time);
+		if (app_config.classes[frame_type].tx_hwtstamp_enabled) {
+			uint64_t fpc = app_config.classes[frame_type].num_frames_per_cycle;
+			uint64_t base = (cycle_number / fpc) * fpc;
+
+			/*
+			 * Record Tx SW timestamp at the cycle-aligned first-frame slot of each
+			 * cycle this batch covers. The completion path looks up sw_ts at the cycle
+			 * boundary (seq rounded down to fpc), so writes must use the same
+			 * alignment. Skip cycles whose first frame was sent in an earlier batch —
+			 * that slot already holds the correct sw_ts and re-stamping it now would
+			 * shrink/invert the measured latency.
+			 */
+			for (c = base; c < end; c += fpc) {
+				if (c < cycle_number)
+					continue;
+				rtt->backlog[c % rtt->backlog_len].sw_ts = ts_to_ns(&tx_time);
+			}
+		} else {
+			/* If Tx HW TS is not enabled, each frame has its own sw_ts. */
+			for (c = cycle_number; c < end; c++)
+				rtt->backlog[c % rtt->backlog_len].sw_ts = ts_to_ns(&tx_time);
+		}
 	}
 
 	/* Increment stats by frame_count */

--- a/src/tsn_thread.c
+++ b/src/tsn_thread.c
@@ -156,8 +156,8 @@ static int tsn_gen_and_send_frames(struct thread_context *thread_context, int so
 				thread_context->tx_frame_data, tsn_config->num_frames_per_cycle,
 				duration);
 
-	for (i = 0; i < len; i++)
-		stat_frame_sent(thread_context->frame_type, sequence_counter_begin + i);
+	if (len > 0)
+		stat_frames_sent_batch(thread_context->frame_type, sequence_counter_begin, len);
 
 	return len;
 }
@@ -349,6 +349,7 @@ static void *tsn_xdp_tx_thread_routine(void *data)
 	xsk = thread_context->xsk;
 	xsk->tx_hwts.rtt = &round_trip_contexts[thread_context->frame_type];
 	xsk->tx_hwts.frames_per_cycle = tsn_config->num_frames_per_cycle;
+	xsk->tx_hwts.meta_data_offset = thread_context->meta_data_offset;
 
 	ret = get_interface_mac_address(tsn_config->interface, source, ETH_ALEN);
 	if (ret < 0) {
@@ -429,7 +430,6 @@ static void *tsn_xdp_tx_thread_routine(void *data)
 			sequence_counter += num_frames;
 		} else {
 			unsigned int received;
-			uint64_t i;
 
 			pthread_mutex_lock(&thread_context->xdp_data_mutex);
 
@@ -445,37 +445,14 @@ static void *tsn_xdp_tx_thread_routine(void *data)
 
 			xsk_ring_prod__submit(&xsk->tx, received);
 
-			if (received > 0) {
-				if (tsn_config->tx_hwtstamp_enabled) {
-					/*
-					 * Once-per-cycle: record TX SW timestamp for the first
-					 * packet in this cycle and count all frames
-					 */
-					stat_frames_sent_batch(thread_context->frame_type,
-							       sequence_counter, received);
-				} else {
-					for (i = sequence_counter; i < sequence_counter + received;
-					     ++i)
-						stat_frame_sent(thread_context->frame_type, i);
-				}
-			}
+			if (received > 0)
+				stat_frames_sent_batch(thread_context->frame_type, sequence_counter,
+						       received);
 
 			xsk->outstanding_tx += received;
 			thread_context->received_frames = 0;
 
 			xdp_complete_tx(xsk);
-
-#ifdef TX_TIMESTAMP
-			if (received > 0 && tsn_config->tx_hwtstamp_enabled) {
-				/*
-				 * TX HW timestamp becomes available in the next cycle
-				 * after the packet is transmitted.
-				 * This is one cycle later than SW timestamp tracked
-				 * using sequence_counter
-				 */
-				xsk->tx_hwts.seq_lagged = sequence_counter;
-			}
-#endif
 
 			pthread_mutex_unlock(&thread_context->xdp_data_mutex);
 		}
@@ -721,6 +698,9 @@ int tsn_threads_create(struct thread_context *thread_context)
 		thread_context->rx_security_context = NULL;
 	}
 
+	thread_context->meta_data_offset =
+		get_meta_data_offset(thread_context->frame_type, tsn_config->security_mode);
+
 	ret = create_rt_thread(&thread_context->tx_task_id, tsn_config->tx_thread_priority,
 			       tsn_config->tx_thread_cpu,
 			       tsn_config->xdp_enabled ? tsn_xdp_tx_thread_routine
@@ -747,9 +727,6 @@ int tsn_threads_create(struct thread_context *thread_context)
 		fprintf(stderr, "Failed to create Tsn Workload context!\n");
 		goto err_thread_wl;
 	}
-
-	thread_context->meta_data_offset =
-		get_meta_data_offset(thread_context->frame_type, tsn_config->security_mode);
 
 	return 0;
 

--- a/src/xdp.c
+++ b/src/xdp.c
@@ -130,102 +130,80 @@ static void xdp_process_tx_timestamp(struct xdp_socket *xsk, uint32_t idx_cq)
 	struct xsk_tx_metadata *meta =
 		(struct xsk_tx_metadata *)(data - sizeof(struct xsk_tx_metadata));
 
-	log_message(LOG_LEVEL_DEBUG,
-		    "XdpTxHwTs CQ[%u]: addr=0x%llx, flags=0x%llx, ts=%llu, seq_lagged=%llu\n",
+	log_message(LOG_LEVEL_DEBUG, "XdpTxHwTs CQ[%u]: addr=0x%llx, flags=0x%llx, ts=%llu\n",
 		    idx_cq, (unsigned long long)addr, (unsigned long long)meta->flags,
-		    (unsigned long long)meta->completion.tx_timestamp,
-		    (unsigned long long)xsk->tx_hwts.seq_lagged);
+		    (unsigned long long)meta->completion.tx_timestamp);
 
 	if (meta->flags & XDP_TXMD_FLAGS_TIMESTAMP) {
 		/* Determine frame type from the round trip context */
 		enum stat_frame_type frame_type = (enum stat_frame_type)(rtt - round_trip_contexts);
 
-		/* Use seq_lagged for now, but only process if HW timestamp is valid */
-		uint64_t seq = xsk->tx_hwts.seq_lagged;
-		size_t idx = seq % rtt->backlog_len;
+		/*
+		 * Derive sequence counter directly from the frame payload to correctly
+		 * correlate this completion with the backlog entry, even if the completion
+		 * arrives more than one cycle late or out of submission order.
+		 *
+		 * For multi-frame cycles only the first frame's backlog slot has a valid
+		 * sw_ts (stat_frames_sent_batch writes once per cycle). Round down to the
+		 * cycle start so that all completions within the same cycle share the same
+		 * backlog index.
+		 */
+		uint64_t fpc = xsk->tx_hwts.frames_per_cycle;
+		uint64_t seq = get_sequence_counter(data, xsk->tx_hwts.meta_data_offset, fpc);
+		uint64_t cycle_seq = (seq / fpc) * fpc;
+		uint64_t frame_in_cycle = seq - cycle_seq;
+		bool is_first = (frame_in_cycle == 0);
+		bool is_last = (frame_in_cycle == fpc - 1);
+		size_t idx = cycle_seq % rtt->backlog_len;
 
 		/* Continue only if both HW and SW timestamps are valid */
 		if (meta->completion.tx_timestamp > 0 && rtt->backlog[idx].sw_ts > 0) {
-			rtt->backlog[idx].hw_ts = meta->completion.tx_timestamp;
+			/*
+			 * Tx latency is measured against the first frame's HW timestamp.
+			 * Only the first-frame completion updates hw_ts and calls
+			 * stat_frame_sent_latency.
+			 */
+			if (is_first) {
+				rtt->backlog[idx].hw_ts = meta->completion.tx_timestamp;
+				stat_frame_sent_latency(frame_type, cycle_seq);
+			}
 
-			/* Increment TX HW timestamp count for this cycle */
-			xsk->tx_hwts.count++;
-
-			stat_frame_sent_latency(frame_type, seq);
-
-			/* Handle timestamp processing based on frames per cycle */
-			if (xsk->tx_hwts.frames_per_cycle == 1) {
-				/*
-				 * Single frame case: measure only ProcFirst (since first == last)
-				 */
-				if (log_stat_user_selected == LOG_TX_TIMESTAMPS &&
-				    config_have_rx_timestamp() &&
-				    meta->completion.tx_timestamp > rtt->backlog[idx].sw_ts) {
-					stat_proc_first_latency(frame_type, seq,
+			/*
+			 * ProcFirst / ProcBatch are decided by the frame's position within
+			 * the cycle (derived from its sequence counter), not by a counter
+			 * of arrivals. This is robust to out-of-order or dropped
+			 * completions. For fpc == 1 the same completion is both first and
+			 * last, so only ProcFirst is recorded.
+			 */
+			if (log_stat_user_selected == LOG_TX_TIMESTAMPS &&
+			    config_have_rx_timestamp() &&
+			    meta->completion.tx_timestamp > rtt->backlog[idx].sw_ts) {
+				if (is_first) {
+					stat_proc_first_latency(frame_type, cycle_seq,
 								meta->completion.tx_timestamp);
-				}
-				/* Reset TX HW timestamp count for next cycle */
-				xsk->tx_hwts.count = 0;
-			} else {
-				/*
-				 * Multiple frames case: handle first and last separately.
-				 * First timestamp completion corresponds to the first
-				 * packet (ProcFirst).
-				 */
-				if (xsk->tx_hwts.count == 1) {
-					/*
-					 * Calculate ProcFirst latency (1st RX HW to 1st TX HW) only
-					 * for mirror mode and valid HW timestamp.
-					 */
-					if (log_stat_user_selected == LOG_TX_TIMESTAMPS &&
-					    config_have_rx_timestamp() &&
-					    meta->completion.tx_timestamp >
-						    rtt->backlog[idx].sw_ts) {
-						stat_proc_first_latency(
-							frame_type, seq,
-							meta->completion.tx_timestamp);
-					}
-				}
-				/* Second timestamp completion corresponds to the last packet
-				   (ProcBatch) */
-				else if (xsk->tx_hwts.count == 2) {
-					/*
-					 * We timestamp two packets per cycle: first (i==0)
-					 * and last (i==num_frames-1). Therefore,
-					 * tx_hwts.count == 2 always refers to the last packet,
-					 * regardless of the number of frames per cycle.
-					 *
-					 * Calculate ProcBatch latency (1st RX HW to last TX HW)
-					 * for mirror mode and valid HW timestamp.
-					 */
-					if (log_stat_user_selected == LOG_TX_TIMESTAMPS &&
-					    config_have_rx_timestamp() &&
-					    meta->completion.tx_timestamp >
-						    rtt->backlog[idx].sw_ts) {
-						stat_proc_batch_latency(
-							frame_type, seq,
-							meta->completion.tx_timestamp);
-					}
-
-					/* Reset TX HW timestamp count for next cycle */
-					xsk->tx_hwts.count = 0;
+				} else if (is_last) {
+					stat_proc_batch_latency(frame_type, cycle_seq,
+								meta->completion.tx_timestamp);
 				}
 			}
 		} else {
 			log_message(LOG_LEVEL_DEBUG,
 				    "XdpTxHwTs: Invalid timestamps for seq=%llu (HW=%llu, "
 				    "SW=%llu), skipping\n",
-				    (unsigned long long)seq,
+				    (unsigned long long)cycle_seq,
 				    (unsigned long long)meta->completion.tx_timestamp,
 				    (unsigned long long)rtt->backlog[idx].sw_ts);
 		}
 	} else {
-		uint64_t seq = xsk->tx_hwts.seq_lagged;
-		size_t idx = seq % rtt->backlog_len;
+		uint64_t seq = get_sequence_counter(data, xsk->tx_hwts.meta_data_offset,
+						    xsk->tx_hwts.frames_per_cycle);
+		uint64_t cycle_seq =
+			(seq / xsk->tx_hwts.frames_per_cycle) * xsk->tx_hwts.frames_per_cycle;
+		size_t idx = cycle_seq % rtt->backlog_len;
 
 		log_message(LOG_LEVEL_WARNING,
 			    "XDP TX HW timestamp missing for expected seq %" PRIu64 ", idx=%zu\n",
-			    seq, idx);
+			    cycle_seq, idx);
 	}
 }
 #endif
@@ -624,7 +602,8 @@ void xdp_complete_tx(struct xdp_socket *xsk)
 
 static unsigned char *xdp_prepare_tx_desc(struct xdp_socket *xsk, struct xdp_desc *tx_desc,
 					  const struct xdp_tx_time __unused *tx_time,
-					  int __unused i, int __unused num_frames, bool __unused tx)
+					  int __unused i, bool __unused want_hw_timestamp,
+					  bool __unused tx)
 {
 	unsigned char *data;
 
@@ -658,8 +637,8 @@ static unsigned char *xdp_prepare_tx_desc(struct xdp_socket *xsk, struct xdp_des
 		}
 #endif
 #ifdef TX_TIMESTAMP
-		/* Timestamp first packet and last packet per cycle */
-		if (xsk->tx_hwtstamp_mode && (i == 0 || i == num_frames - 1)) {
+		/* Timestamp first and last frame of each cycle (decision made by caller) */
+		if (xsk->tx_hwtstamp_mode && want_hw_timestamp) {
 			meta->flags |= XDP_TXMD_FLAGS_TIMESTAMP;
 			/* Initialize TX HW timestamp */
 			meta->completion.tx_timestamp = 0;
@@ -714,8 +693,8 @@ void xdp_gen_and_send_frames(struct xdp_socket *xsk, const struct xdp_gen_config
 				     XSK_RING_PROD__DEFAULT_NUM_DESCS;
 
 		/* Get frame and prepare it */
-		data = xdp_prepare_tx_desc(xsk, tx_desc, xdp->tx_time, i, xdp->num_frames_per_cycle,
-					   true);
+		data = xdp_prepare_tx_desc(xsk, tx_desc, xdp->tx_time, i,
+					   i == 0 || i == xdp->num_frames_per_cycle - 1, true);
 
 		frame_config.mode = xdp->mode;
 		frame_config.security_context = xdp->security_context;
@@ -758,9 +737,6 @@ void xdp_gen_and_send_frames(struct xdp_socket *xsk, const struct xdp_gen_config
 		 */
 		stat_frames_sent_batch(xdp->frame_type, xdp->sequence_counter_begin,
 				       xdp->num_frames_per_cycle);
-
-		/* Update the sequence number for expected HW timestamp in next cycle */
-		xsk->tx_hwts.seq_lagged = xdp->sequence_counter_begin;
 		return;
 	}
 #endif
@@ -857,8 +833,30 @@ unsigned int xdp_receive_frames(struct xdp_socket *xsk, size_t frame_length, boo
 			tx_desc->len = frame_length;
 
 			/* Prepare tx desc with Tx Time or Tx HW timestamp */
-			if (xsk->tx_time_mode || xsk->tx_hwtstamp_mode)
-				xdp_prepare_tx_desc(xsk, tx_desc, tx_time, i, received, false);
+			if (xsk->tx_time_mode || xsk->tx_hwtstamp_mode) {
+				bool want_hw_ts = false;
+
+#ifdef TX_TIMESTAMP
+				/*
+				 * Decide first/last HW-timestamp from the frame's
+				 * own position within its cycle, not from the RX
+				 * batch position. The RX batch is not aligned to
+				 * the sender's cycle boundaries (e.g. one frame at
+				 * a time), so using the batch index would attach
+				 * the TIMESTAMP flag to the wrong frame.
+				 */
+				if (xsk->tx_hwtstamp_mode) {
+					uint64_t fpc = xsk->tx_hwts.frames_per_cycle;
+					uint64_t seq = get_sequence_counter(
+						packet, xsk->tx_hwts.meta_data_offset, fpc);
+					uint64_t frame_in_cycle = seq % fpc;
+
+					want_hw_ts = (frame_in_cycle == 0) ||
+						     (frame_in_cycle == fpc - 1);
+				}
+#endif
+				xdp_prepare_tx_desc(xsk, tx_desc, tx_time, i, want_hw_ts, false);
+			}
 		} else {
 			/* Move buffer back to fill queue */
 			*xsk_ring_prod__fill_addr(&xsk->umem.fq, idx_fq++) = orig;

--- a/src/xdp.h
+++ b/src/xdp.h
@@ -43,12 +43,10 @@ struct xsk_umem_info {
 struct xdp_tx_hwts {
 	/* Store HW timestamps from AF_XDP completion queue */
 	struct round_trip_context *rtt;
-	/* Sequence number for TX HW timestamp (available one cycle later) */
-	int64_t seq_lagged;
-	/* Counter for tracking TX HW timestamp completions in current cycle (max 2: first+last) */
-	uint32_t count;
 	/* Total number of frames per cycle (needed to identify last packet) */
 	uint32_t frames_per_cycle;
+	/* Offset of reference_meta_data within the frame (for sequence counter extraction) */
+	uint32_t meta_data_offset;
 };
 
 struct xdp_socket {


### PR DESCRIPTION
The TX HW timestamp completion path correlated completions with backlog slots via seq_lagged, a snapshot of the previous cycle's sequence counter. This assumes TX completions are consumed exactly one cycle after submission. If a completion is delayed by two or more cycles, the lookup uses the wrong backlog slot: sw_ts may belong to a newer cycle, which can increment TxHwTimestampMissing, and rx_hw_ts may belong to a different cycle, which corrupts ProcFirst/ProcBatch latency.

Use the sequence counter stored in the completed frame payload instead. Round it down to the cycle start so all timestamped frames in a cycle use the same once-per-cycle sw_ts slot, and derive first/last frame classification from seq % frames_per_cycle.

In mirror mode, attach XDP_TXMD_FLAGS_TIMESTAMP based on the mirrored frame's position within the sender cycle instead of its position within the RX batch. RX batches are not guaranteed to align with cycle boundaries, so the old batch-index check could timestamp the wrong frame and produce unpaired ProcFirst/ProcBatch samples.

Also refresh sw_ts for every cycle-start slot covered by a transmitted batch, so multi-cycle mirror batches do not leave later cycle slots with stale timestamps from a previous backlog wrap.

Co-developed-by: Song Yoong Siang <yoong.siang.song@intel.com>