### PR TITLE
tests/intel_kpi: Add i226 XDP 125us test with PTP hardware timestamp

### DIFF
--- a/tests/intel_kpi/i226_xdp_125us_1x64b_11k_proclat/flow_mirror.sh
+++ b/tests/intel_kpi/i226_xdp_125us_1x64b_11k_proclat/flow_mirror.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Copyright (C) 2026 Linutronix GmbH
+# Author Kurt Kanzenbach <kurt@linutronix.de>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Setup the Tx and Rx traffic flows for Intel i226 NIC(s) KPI testing.
+#
+
+set -e
+
+source ../../lib/common.sh
+source ../../lib/igc.sh
+
+#
+# Command line arguments.
+#
+INTERFACE=$1
+CYCLETIME_NS=$2
+BASETIME=$3
+
+[ -z $INTERFACE ] && INTERFACE="enp3s0"                          # default: enp3s0
+[ -z $CYCLETIME_NS ] && CYCLETIME_NS="125000"                    # default: 125us
+[ -z $BASETIME ] && BASETIME=$(date '+%s000000000' -d '-30 sec') # default: now - 30s
+
+load_kernel_modules
+
+igc_start "${INTERFACE}"
+ethtool -C ${INTERFACE} rx-usecs 0
+
+#
+# Split traffic between TSN High Stream and everything else.
+#
+ENTRY1_NS="75000" # Everything else
+ENTRY2_NS="50000" # TSN High Stream
+
+#
+# Tx Assignment with Qbv and full hardware offload.
+#
+# PCP 6 - Tx Q 1 - TSN High Stream
+# PCP X - Tx Q 0 - Everything else
+#
+tc qdisc replace dev ${INTERFACE} handle 100 parent root taprio num_tc 2 \
+  map 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 \
+  queues 1@0 1@1 \
+  base-time ${BASETIME} \
+  sched-entry S 0x03 ${ENTRY1_NS} \
+  sched-entry S 0x02 ${ENTRY2_NS} \
+  flags 0x02
+
+#
+# Rx Queues Assignment.
+#
+# PCP 6 - Rx Q 1 - TSN High Stream
+# PCP X - Rx Q 0 - Everything else
+RXQUEUES=(0 1 0 0 0 0 0 0 0 0)
+igc_rx_queues_assign "${INTERFACE}" RXQUEUES
+
+setup_irqs "${INTERFACE}"
+
+exit 0

--- a/tests/intel_kpi/i226_xdp_125us_1x64b_11k_proclat/flow_ref.sh
+++ b/tests/intel_kpi/i226_xdp_125us_1x64b_11k_proclat/flow_ref.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Copyright (C) 2026 Linutronix GmbH
+# Author Kurt Kanzenbach <kurt@linutronix.de>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Setup the Tx and Rx traffic flows for Intel i226 NIC(s) KPI testing.
+#
+
+set -e
+
+source ../../lib/common.sh
+source ../../lib/igc.sh
+
+#
+# Command line arguments.
+#
+INTERFACE=$1
+CYCLETIME_NS=$2
+BASETIME=$3
+
+[ -z $INTERFACE ] && INTERFACE="enp3s0"                          # default: enp3s0
+[ -z $CYCLETIME_NS ] && CYCLETIME_NS="125000"                    # default: 125us
+[ -z $BASETIME ] && BASETIME=$(date '+%s000000000' -d '-30 sec') # default: now - 30s
+
+load_kernel_modules
+
+igc_start "${INTERFACE}"
+ethtool -C ${INTERFACE} rx-usecs 0
+
+#
+# Split traffic between TSN High Stream and everything else.
+#
+ENTRY1_NS="50000" # TSN High Stream
+ENTRY2_NS="75000" # Everything else
+
+#
+# Tx Assignment with Qbv and full hardware offload.
+#
+# PCP 6 - Tx Q 1 - TSN High Stream
+# PCP X - Tx Q 0 - Everything else
+#
+tc qdisc replace dev ${INTERFACE} handle 100 parent root taprio num_tc 2 \
+  map 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 \
+  queues 1@0 1@1 \
+  base-time ${BASETIME} \
+  sched-entry S 0x02 ${ENTRY1_NS} \
+  sched-entry S 0x01 ${ENTRY2_NS} \
+  flags 0x02
+
+#
+# Rx Queues Assignment.
+#
+# PCP 6 - Rx Q 1 - TSN High Stream
+# PCP X - Rx Q 0 - Everything else
+RXQUEUES=(0 1 0 0 0 0 0 0 0 0)
+igc_rx_queues_assign "${INTERFACE}" RXQUEUES
+
+setup_irqs "${INTERFACE}"
+
+exit 0

--- a/tests/intel_kpi/i226_xdp_125us_1x64b_11k_proclat/mirror.sh
+++ b/tests/intel_kpi/i226_xdp_125us_1x64b_11k_proclat/mirror.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Copyright (C) 2026 Linutronix GmbH
+# Author Kurt Kanzenbach <kurt@linutronix.de>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+set -e
+
+cd "$(dirname "$0")"
+
+# Start PTP
+../../../scripts/ptp.sh enp3s0
+sleep 30
+
+# Configure flow
+./flow_mirror.sh enp3s0
+sleep 30
+
+# Start one instance of mirror application
+cp ../../../build/xdp_kern_*.o .
+../../../build/mirror -c mirror.yaml > /dev/shm/mirror.log &
+
+exit 0

--- a/tests/intel_kpi/i226_xdp_125us_1x64b_11k_proclat/mirror.yaml
+++ b/tests/intel_kpi/i226_xdp_125us_1x64b_11k_proclat/mirror.yaml
@@ -1,0 +1,65 @@
+---
+#
+# Copyright (C) 2026 Linutronix GmbH
+# Author Kurt Kanzenbach <kurt@linutronix.de>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Mirror YAML configuration file for Intel i226 NIC(s) KPI testing.
+#
+Application:
+  ApplicationClockId: CLOCK_TAI
+  # ApplicationBaseStartTimeNS: 0
+  ApplicationBaseCycleTimeNS: 125us
+  ApplicationTxBaseOffsetNS: 80us
+  ApplicationRxBaseOffsetNS: 30us
+  ApplicationXdpProgram: xdp_kern_profinet_vid100.o
+TsnHigh:
+  TsnHighEnabled: true
+  TsnHighXdpEnabled: true
+  TsnHighXdpSkbMode: false
+  TsnHighXdpZcMode: true
+  TsnHighXdpWakeupMode: true
+  TsnHighXdpBusyPollMode: true
+  TsnHighTxTimeStampEnabled: true
+  TsnHighVid: 100
+  TsnHighNumFramesPerCycle: 1
+  TsnHighPayloadPattern: |
+    TsnHighPayloadPattern
+  TsnHighFrameLength: 64
+  TsnHighRxQueue: 1
+  TsnHighTxQueue: 1
+  TsnHighSocketPriority: 6
+  TsnHighTxThreadPriority: 98
+  TsnHighRxThreadPriority: 98
+  TsnHighTxThreadCpu: 1
+  TsnHighRxThreadCpu: 1
+  TsnHighInterface: enp3s0
+  TsnHighDestination: a8:74:1d:9d:36:14
+  TsnHighRxWorkloadEnabled: true
+  TsnHighRxWorkloadFile: ../../workloads/pointer_chasing/pointer_chasing.so
+  TsnHighRxWorkloadSetupFunction: ptr_chase_setup
+  TsnHighRxWorkloadSetupArguments: "0xEC000 0x3B000"
+  TsnHighRxWorkloadTeardownFunction: ptr_chase_teardown
+  TsnHighRxWorkloadFunction: run_ptr_chasing
+  TsnHighRxWorkloadPrewarm: false
+  TsnHighRxWorkloadSkipCount: 100
+  TsnHighRxWorkloadThreadCpu: 1
+  TsnHighRxWorkloadThreadPriority: 80
+Log:
+  LogThreadPriority: 1
+  LogThreadCpu: 0
+  LogFile: /var/log/mirror_vid100.log
+  LogLevel: Info
+LogMqtt:
+  LogMqtt: false
+  LogMqttThreadPriority: 10
+  LogMqttThreadCpu: 0
+  LogMqttBrokerIP: 127.0.0.1
+  LogMqttBrokerPort: 1883
+  LogMqttMeasurementName: mirror
+Debug:
+  DebugStopTraceOnOutlier: false
+  DebugStopTraceOnError: false
+  DebugMonitorMode: false
+  DebugMonitorDestination: 44:44:44:44:44:44

--- a/tests/intel_kpi/i226_xdp_125us_1x64b_11k_proclat/ref.sh
+++ b/tests/intel_kpi/i226_xdp_125us_1x64b_11k_proclat/ref.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Copyright (C) 2026 Linutronix GmbH
+# Author Kurt Kanzenbach <kurt@linutronix.de>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+set -e
+
+cd "$(dirname "$0")"
+
+# Start PTP
+../../../scripts/ptp.sh enp3s0
+sleep 30
+
+# Configure flow
+./flow_ref.sh enp3s0
+sleep 30
+
+# Start one instance of reference application
+cp ../../../build/xdp_kern_*.o .
+../../../build/reference -c reference.yaml > /dev/shm/ref.log &
+
+exit 0

--- a/tests/intel_kpi/i226_xdp_125us_1x64b_11k_proclat/reference.yaml
+++ b/tests/intel_kpi/i226_xdp_125us_1x64b_11k_proclat/reference.yaml
@@ -1,0 +1,55 @@
+---
+#
+# Copyright (C) 2026 Linutronix GmbH
+# Author Kurt Kanzenbach <kurt@linutronix.de>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Reference YAML configuration file for Intel i226 NIC(s) KPI testing.
+#
+Application:
+  ApplicationClockId: CLOCK_TAI
+  # ApplicationBaseStartTimeNS: 0
+  ApplicationBaseCycleTimeNS: 125us
+  ApplicationTxBaseOffsetNS: 80us
+  ApplicationRxBaseOffsetNS: 15us
+  ApplicationXdpProgram: xdp_kern_profinet_vid100.o
+TsnHigh:
+  TsnHighEnabled: true
+  TsnHighXdpEnabled: true
+  TsnHighXdpSkbMode: false
+  TsnHighXdpZcMode: true
+  TsnHighXdpWakeupMode: true
+  TsnHighXdpBusyPollMode: true
+  TsnHighTxTimeStampEnabled: false
+  TsnHighVid: 100
+  TsnHighNumFramesPerCycle: 1
+  TsnHighPayloadPattern: |
+    TsnHighPayloadPattern
+  TsnHighFrameLength: 64
+  TsnHighRxQueue: 1
+  TsnHighTxQueue: 1
+  TsnHighSocketPriority: 6
+  TsnHighTxThreadPriority: 98
+  TsnHighRxThreadPriority: 98
+  TsnHighTxThreadCpu: 1
+  TsnHighRxThreadCpu: 1
+  TsnHighInterface: enp3s0
+  TsnHighDestination: a8:74:1d:9d:98:d8
+Log:
+  LogThreadPriority: 1
+  LogThreadCpu: 0
+  LogFile: /var/log/reference_vid100.log
+  LogLevel: Info
+LogMqtt:
+  LogMqtt: false
+  LogMqttThreadPriority: 10
+  LogMqttThreadCpu: 0
+  LogMqttBrokerIP: 127.0.0.1
+  LogMqttBrokerPort: 1883
+  LogMqttMeasurementName: reference
+Debug:
+  DebugStopTraceOnOutlier: false
+  DebugStopTraceOnError: false
+  DebugMonitorMode: false
+  DebugMonitorDestination: 44:44:44:44:44:44


### PR DESCRIPTION
Add test case for Intel i226 NIC KPI evaluation with 125us cycle time using AF_XDP zero-copy mode.

Configuration highlights:
 - Enable processing latency metric
 - Workload on Reference: none
 - Workload on Mirror: 11k instructions per control loop (IPCL)
 - AF_XDP zero-copy mode with busy polling optimization
 - Disable interrupt coalescing for immediate interrupt firing

Co-developed-by: Chwee-Lin Choong <chwee.lin.choong@intel.com>