### PR TITLE
tests/intel_kpi: disable XDP busy polling for i226 processing-latency…

### DIFF
--- a/tests/intel_kpi/i226_xdp_125us_1x64b_11k_proclat/mirror.yaml
+++ b/tests/intel_kpi/i226_xdp_125us_1x64b_11k_proclat/mirror.yaml
@@ -20,7 +20,7 @@ TsnHigh:
   TsnHighXdpSkbMode: false
   TsnHighXdpZcMode: true
   TsnHighXdpWakeupMode: true
-  TsnHighXdpBusyPollMode: true
+  TsnHighXdpBusyPollMode: false
   TsnHighTxTimeStampEnabled: true
   TsnHighVid: 100
   TsnHighNumFramesPerCycle: 1

--- a/tests/intel_kpi/i226_xdp_125us_1x64b_11k_proclat/reference.yaml
+++ b/tests/intel_kpi/i226_xdp_125us_1x64b_11k_proclat/reference.yaml
@@ -20,7 +20,7 @@ TsnHigh:
   TsnHighXdpSkbMode: false
   TsnHighXdpZcMode: true
   TsnHighXdpWakeupMode: true
-  TsnHighXdpBusyPollMode: true
+  TsnHighXdpBusyPollMode: false
   TsnHighTxTimeStampEnabled: false
   TsnHighVid: 100
   TsnHighNumFramesPerCycle: 1

--- a/tests/intel_kpi/i226_xdp_1ms_1x64b_57k_proclat/mirror.yaml
+++ b/tests/intel_kpi/i226_xdp_1ms_1x64b_57k_proclat/mirror.yaml
@@ -20,7 +20,7 @@ TsnHigh:
   TsnHighXdpSkbMode: false
   TsnHighXdpZcMode: true
   TsnHighXdpWakeupMode: true
-  TsnHighXdpBusyPollMode: true
+  TsnHighXdpBusyPollMode: false
   TsnHighTxTimeStampEnabled: true
   TsnHighVid: 100
   TsnHighNumFramesPerCycle: 1

--- a/tests/intel_kpi/i226_xdp_1ms_1x64b_57k_proclat/reference.yaml
+++ b/tests/intel_kpi/i226_xdp_1ms_1x64b_57k_proclat/reference.yaml
@@ -20,7 +20,7 @@ TsnHigh:
   TsnHighXdpSkbMode: false
   TsnHighXdpZcMode: true
   TsnHighXdpWakeupMode: true
-  TsnHighXdpBusyPollMode: true
+  TsnHighXdpBusyPollMode: false
   TsnHighTxTimeStampEnabled: false
   TsnHighVid: 100
   TsnHighNumFramesPerCycle: 1


### PR DESCRIPTION
… tests

The i226 processing-latency tests do not configure napi_defer_hard_irqs or gro_flush_timeout. The flow_mirror.sh and flow_ref.sh scripts only disable Rx interrupt coalescing with "rx-usecs 0", allowing packets to be processed immediately after an interrupt.

As a result, XDP busy polling provides little to no benefit for these tests. Disable it.

Tested on a pair of Intel PTL systems for 24 hours with no outliers observed in round-trip time, processing latency, or RT workload results.

Suggested-by: Kurt Kanzenbach <kurt@linutronix.de>