### PR TITLE
packet: Add HW timestamp support for AF_PACKET

### DIFF
--- a/Documentation/processing_latency.rst
+++ b/Documentation/processing_latency.rst
@@ -258,10 +258,10 @@ the Timestamp Details table above:
    * - **Rx**
      - RX App TS - RX HW TS
      - Total RX path latency
-   * - **RxHw2Xdp**
+   * - **RxHw2Sw**
      - RX SW TS - RX HW TS
      - NIC HW to earliest SW timestamp latency
-   * - **RxXdp2App**
+   * - **RxSw2App**
      - RX App TS - RX SW TS
      - Earliest SW timestamp to userspace latency
    * - **Tx**
@@ -277,14 +277,14 @@ Measures total receive-path latency from NIC hardware timestamp to the userspace
 timestamp captured when the application processes the received frame.
 Useful for assessing overall RX path performance.
 
-**RxHw2Xdp:**
+**RxHw2Sw:**
 Measures latency from where the NIC records the hardware timestamp
 (MAC / PHY / DMA write depending on NIC implementation) to the earliest available software
 timestamp: execution of the XDP program for AF_XDP, or the kernel's
 ``SOF_TIMESTAMPING_RX_SOFTWARE`` timestamp for AF_PACKET.
 Useful for debugging NIC to kernel boundary delays.
 
-**RxXdp2App:**
+**RxSw2App:**
 Measures latency between that earliest software timestamp and the application's receive
 handler. Includes XSK ring polling and packet extraction for AF_XDP, or ``recvmmsg()``
 processing for AF_PACKET.

--- a/Documentation/processing_latency.rst
+++ b/Documentation/processing_latency.rst
@@ -13,7 +13,8 @@ Processing Latency
 Processing latency metrics quantify how long the Mirror DUT takes to process a full cycle
 of packets. It is measured from the hardware RX timestamp of the first packet in the cycle
 to the hardware TX timestamp of the response packet(s). These measurements work only in
-Mirror mode and only when AF_XDP and hardware timestamping are enabled.
+Mirror mode, with either AF_XDP or AF_PACKET, when both RX and TX hardware timestamping
+are enabled.
 
 These metrics allow evaluating Mirror-side timing behavior for both:
 
@@ -44,6 +45,13 @@ latency metrics measure:
             [Pkt 1 RX] ◄────────── ProcFirst ──────────► [Pkt 1 TX]
             [Pkt 1 RX] ◄────────── ProcBatch ──────────► [Pkt N TX]
 
+.. note::
+   The diagram above shows the AF_XDP case, where the "XDP" stage is a program running on
+   the NIC driver's RX path. Over AF_PACKET, there is no XDP program; the same intermediate
+   software timestamp (RX SW TS) is instead captured by the kernel's generic RX timestamping
+   (``SOF_TIMESTAMPING_RX_SOFTWARE``). The rest of the flow, and all metrics below, are
+   identical for both transports.
+
 Timestamp Details
 ^^^^^^^^^^^^^^^^^
 
@@ -62,9 +70,9 @@ The table below provides precise details for each timestamp capture point:
      - Packet arrival
      - HW timestamp at NIC
    * - **RX SW TS**
-     - XDP Hook
+     - XDP hook / kernel RX
      - After DMA completion
-     - XDP program timestamp
+     - XDP program, or RX_SOFTWARE flag
    * - **RX App TS**
      - Userspace
      - After XSK polling
@@ -81,7 +89,9 @@ The table below provides precise details for each timestamp capture point:
 
 **RX HW TS:** Exact hardware capture point varies by NIC (MAC layer, PHY, or DMA descriptor write).
 
-**RX SW TS:** Timestamp is taken when the XDP program executes after the NIC DMA completes.
+**RX SW TS:** For AF_XDP, taken when the XDP program executes after the NIC DMA completes. For
+AF_PACKET, this is the kernel's software RX timestamp (``SOF_TIMESTAMPING_RX_SOFTWARE``),
+captured at the ingress of the network stack, before the frame is dispatched to any socket.
 
 **RX App TS:** Timestamp is captured at stat_frame_received(), after userspace dequeues the packet.
 
@@ -90,20 +100,23 @@ The table below provides precise details for each timestamp capture point:
 **TX HW TS:** Exact capture point varies by NIC (MAC egress, PHY, or descriptor completion).
 
 .. note::
-   On the RX path, an intermediate software timestamp (RX SW TS) is available because,
-   in AF_XDP mode, all packets are processed by the XDP program before they are
-   delivered to userspace.
+   On the RX path, an intermediate software timestamp (RX SW TS) is available for both
+   transports: for AF_XDP because all packets are processed by the XDP program before
+   they are delivered to userspace, and for AF_PACKET because the kernel timestamps every
+   frame at the ingress of the network stack, before it is dispatched to any socket.
 
-   On the TX path there is no equivalent midpoint timestamp: with AF_XDP, packets are
-   transmitted directly from userspace via the TX ring, so only the userspace
-   submission timestamp (TX SW TS) and the NIC hardware transmit timestamp (TX HW TS)
-   are available.
+   On the TX path there is no equivalent midpoint timestamp for either transport: with
+   AF_XDP, packets are transmitted directly from userspace via the TX ring; with AF_PACKET,
+   only the userspace submission timestamp (TX SW TS) and the NIC hardware transmit
+   timestamp (TX HW TS) are requested, even though the kernel could in principle also
+   supply a software TX timestamp (``SOF_TIMESTAMPING_TX_SOFTWARE``). This is a deliberate
+   choice to keep both transports' Tx latency model identical.
 
 
 Processing Latency Metrics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following metrics are available in Mirror mode with AF_XDP when both RX and TX
+The following metrics are available in Mirror mode with AF_XDP or AF_PACKET when both RX and TX
 hardware timestamping are enabled:
 
 
@@ -144,10 +157,12 @@ Configuration
 Dependencies
 ------------
 
-Processing latency metrics require both RX and TX hardware timestamp support.
-The following table summarizes all dependencies:
+Processing latency metrics require both RX and TX hardware timestamp support. Requirements
+differ depending on the transport used for the traffic class.
 
-.. list-table:: Hardware Timestamp Dependencies
+**AF_XDP** (``<Class>XdpEnabled: true``):
+
+.. list-table:: AF_XDP Hardware Timestamp Dependencies
    :widths: 15 20 20
    :header-rows: 1
 
@@ -172,6 +187,12 @@ The following table summarizes all dependencies:
    timestamping capabilities first became available in the kernel. Real support
    depends on NIC driver implementation.
 
+**AF_PACKET** (``<Class>XdpEnabled: false``):
+
+Needs only a NIC driver supporting ``SIOCSHWTSTAMP`` and ``SO_TIMESTAMPING``; no particular
+libbpf/libxdp version is required, since this path uses plain socket APIs instead of AF_XDP
+metadata. Check driver support with ``ethtool -T <interface>``.
+
 Build Configuration
 -------------------
 
@@ -182,11 +203,18 @@ To enable processing latency metrics, build with both RX and TX timestamp suppor
    cmake -DCMAKE_BUILD_TYPE=Release -DRX_TIMESTAMP=TRUE -DTX_TIMESTAMP=TRUE ..
 
 Enable TX hardware timestamping for your traffic class in the YAML configuration.
-For example, to enable it for TsnHigh:
+For example, to enable it for TsnHigh over AF_XDP:
 
 .. code-block:: yaml
 
    TsnHighXdpEnabled: true
+   TsnHighTxTimeStampEnabled: true
+
+Or over AF_PACKET (no libxdp/libbpf version requirements, see Dependencies above):
+
+.. code-block:: yaml
+
+   TsnHighXdpEnabled: false
    TsnHighTxTimeStampEnabled: true
 
 .. Note:: Hardware timestamping must be supported by the NIC. If unsupported,
@@ -232,10 +260,10 @@ the Timestamp Details table above:
      - Total RX path latency
    * - **RxHw2Xdp**
      - RX SW TS - RX HW TS
-     - NIC HW to XDP hook latency
+     - NIC HW to earliest SW timestamp latency
    * - **RxXdp2App**
      - RX App TS - RX SW TS
-     - XDP hook to userspace latency
+     - Earliest SW timestamp to userspace latency
    * - **Tx**
      - TX HW TS - TX SW TS
      - TX ring to NIC HW latency
@@ -251,12 +279,15 @@ Useful for assessing overall RX path performance.
 
 **RxHw2Xdp:**
 Measures latency from where the NIC records the hardware timestamp
-(MAC / PHY / DMA write depending on NIC implementation) to execution of the XDP program.
+(MAC / PHY / DMA write depending on NIC implementation) to the earliest available software
+timestamp: execution of the XDP program for AF_XDP, or the kernel's
+``SOF_TIMESTAMPING_RX_SOFTWARE`` timestamp for AF_PACKET.
 Useful for debugging NIC to kernel boundary delays.
 
 **RxXdp2App:**
-Measures latency between the XDP program and the application's receive handler.
-Includes XSK ring polling and packet extraction.
+Measures latency between that earliest software timestamp and the application's receive
+handler. Includes XSK ring polling and packet extraction for AF_XDP, or ``recvmmsg()``
+processing for AF_PACKET.
 Useful for debugging kernel to userspace delays.
 
 **Tx:**

--- a/Documentation/statistics.rst
+++ b/Documentation/statistics.rst
@@ -81,7 +81,7 @@ The following table shows all gathered statistics. All statistics are collected 
      - Latency from NIC hardware to user space based on hardware timestamps.
        See :ref:`Processing Latency <ProcessingLatency>` for detailed information.
 
-   * - RxHw2Xdp[Min,Max,Av] [us]
+   * - RxHw2Sw[Min,Max,Av] [us]
      - Latency from NIC hardware to the earliest available software timestamp (the XDP program
        for AF_XDP, or the kernel's software RX timestamp for AF_PACKET) based on hardware
        timestamps. See :ref:`Processing Latency <ProcessingLatency>` for detailed information.
@@ -89,7 +89,7 @@ The following table shows all gathered statistics. All statistics are collected 
    * - RxWorkload[Min,Max,Av] [us]
      - Duration of workload execution.
 
-   * - RxXdp2App[Min,Max,Av] [us]
+   * - RxSw2App[Min,Max,Av] [us]
      - Latency from the earliest available software timestamp (the XDP program for AF_XDP, or
        the kernel's software RX timestamp for AF_PACKET) to user space.
        See :ref:`Processing Latency <ProcessingLatency>` for detailed information.

--- a/Documentation/statistics.rst
+++ b/Documentation/statistics.rst
@@ -82,14 +82,16 @@ The following table shows all gathered statistics. All statistics are collected 
        See :ref:`Processing Latency <ProcessingLatency>` for detailed information.
 
    * - RxHw2Xdp[Min,Max,Av] [us]
-     - Latency from NIC hardware to XDP program based on hardware timestamps.
-       See :ref:`Processing Latency <ProcessingLatency>` for detailed information.
+     - Latency from NIC hardware to the earliest available software timestamp (the XDP program
+       for AF_XDP, or the kernel's software RX timestamp for AF_PACKET) based on hardware
+       timestamps. See :ref:`Processing Latency <ProcessingLatency>` for detailed information.
 
    * - RxWorkload[Min,Max,Av] [us]
      - Duration of workload execution.
 
    * - RxXdp2App[Min,Max,Av] [us]
-     - Latency from XDP program to user space.
+     - Latency from the earliest available software timestamp (the XDP program for AF_XDP, or
+       the kernel's software RX timestamp for AF_PACKET) to user space.
        See :ref:`Processing Latency <ProcessingLatency>` for detailed information.
 
    * - Tx[Min,Max,Av] [us]

--- a/src/config.c
+++ b/src/config.c
@@ -1371,19 +1371,15 @@ bool config_sanity_check(void)
 	}
 
 	if (!config_have_tx_timestamp() &&
-	    ((app_config.classes[GENERICL2_FRAME_TYPE].tx_hwtstamp_enabled &&
-	      app_config.classes[GENERICL2_FRAME_TYPE].xdp_enabled) ||
-	     (app_config.classes[RTC_FRAME_TYPE].tx_hwtstamp_enabled &&
-	      app_config.classes[RTC_FRAME_TYPE].xdp_enabled) ||
-	     (app_config.classes[RTA_FRAME_TYPE].tx_hwtstamp_enabled &&
-	      app_config.classes[RTA_FRAME_TYPE].xdp_enabled) ||
-	     (app_config.classes[TSN_HIGH_FRAME_TYPE].tx_hwtstamp_enabled &&
-	      app_config.classes[TSN_HIGH_FRAME_TYPE].xdp_enabled) ||
-	     (app_config.classes[TSN_LOW_FRAME_TYPE].tx_hwtstamp_enabled &&
-	      app_config.classes[TSN_LOW_FRAME_TYPE].xdp_enabled))) {
-		fprintf(stderr, "XDP Tx HW Timestamp requires TX_TIMESTAMP build support!\n");
-		fprintf(stderr, "Rebuild with -DTX_TIMESTAMP=ON (requires libxdp >= v1.5.2 and "
-				"Linux kernel >= v6.8).\n");
+	    (app_config.classes[GENERICL2_FRAME_TYPE].tx_hwtstamp_enabled ||
+	     app_config.classes[RTC_FRAME_TYPE].tx_hwtstamp_enabled ||
+	     app_config.classes[RTA_FRAME_TYPE].tx_hwtstamp_enabled ||
+	     app_config.classes[TSN_HIGH_FRAME_TYPE].tx_hwtstamp_enabled ||
+	     app_config.classes[TSN_LOW_FRAME_TYPE].tx_hwtstamp_enabled)) {
+		fprintf(stderr, "Tx HW Timestamp requires TX_TIMESTAMP build support!\n");
+		fprintf(stderr,
+			"Rebuild with -DTX_TIMESTAMP=ON (AF_XDP additionally requires libxdp "
+			">= v1.5.2 and Linux kernel >= v6.8).\n");
 		return false;
 	}
 

--- a/src/config.h
+++ b/src/config.h
@@ -310,4 +310,10 @@ static inline bool config_have_tx_timestamp(void)
 #endif
 }
 
+/* RX HW timestamping (AF_XDP or AF_PACKET) is limited to TC_XDP classes. */
+static inline bool config_class_rx_timestamp_enabled(enum stat_frame_type frame_type)
+{
+	return config_have_rx_timestamp() && (BIT(frame_type) & TC_XDP);
+}
+
 #endif /* _CONFIG_H_ */

--- a/src/config.h
+++ b/src/config.h
@@ -316,4 +316,10 @@ static inline bool config_class_rx_timestamp_enabled(enum stat_frame_type frame_
 	return config_have_rx_timestamp() && (BIT(frame_type) & TC_XDP);
 }
 
+/* TX HW timestamping (AF_XDP or AF_PACKET), opted in per class via TxTimeStampEnabled. */
+static inline bool config_class_tx_timestamp_enabled(enum stat_frame_type frame_type)
+{
+	return config_have_tx_timestamp() && app_config.classes[frame_type].tx_hwtstamp_enabled;
+}
+
 #endif /* _CONFIG_H_ */

--- a/src/layer2_thread.c
+++ b/src/layer2_thread.c
@@ -19,6 +19,7 @@
 #include "layer2_thread.h"
 #include "log.h"
 #include "net.h"
+#include "packet.h"
 #include "stat.h"
 #include "tc.h"
 #include "thread.h"
@@ -136,6 +137,8 @@ static int generic_l2_rx_frame(void *data, unsigned char *frame_data, size_t len
 
 	if (config_have_rx_timestamp() && l2_config->xdp_enabled)
 		xdp_get_timestamp_metadata(frame_data, &rx_hw_timestamp, &rx_sw_timestamp);
+	else if (config_have_rx_timestamp())
+		packet_get_timestamp_metadata(frame_data, &rx_hw_timestamp, &rx_sw_timestamp);
 	out_of_order = sequence_counter != thread_context->rx_sequence_counter;
 	payload_mismatch = memcmp(p, expected_pattern, expected_pattern_length);
 	frame_id_mismatch = false;

--- a/src/log.c
+++ b/src/log.c
@@ -142,7 +142,7 @@ static int log_add_proc_first_stats(const char *name, enum stat_frame_type frame
 	int ret;
 
 	if (app_config.classes[frame_type].tx_hwtstamp_enabled && config_have_rx_timestamp() &&
-	    app_config.classes[frame_type].xdp_enabled && stat->proc_first_count > 0) {
+	    stat->proc_first_count > 0) {
 		ret = snprintf(*buffer, *length,
 			       "%sProcFirstMin=%" PRIu64 " [us] | %sProcFirstMax=%" PRIu64
 			       " [us] | %sProcFirstAvg=%lf [us] | "
@@ -162,7 +162,7 @@ static int log_add_proc_batch_stats(const char *name, enum stat_frame_type frame
 	int ret;
 
 	if (app_config.classes[frame_type].tx_hwtstamp_enabled && config_have_rx_timestamp() &&
-	    app_config.classes[frame_type].xdp_enabled && stat->proc_batch_count > 0) {
+	    stat->proc_batch_count > 0) {
 		ret = snprintf(*buffer, *length,
 			       "%sProcBatchMin=%" PRIu64 " [us] | %sProcBatchMax=%" PRIu64
 			       " [us] | %sProcBatchAvg=%lf [us] | "
@@ -201,14 +201,13 @@ static int log_add_rx_hwts_stats(const char *name, enum stat_frame_type frame_ty
 	return 0;
 }
 
-static int log_add_xdp_tx_stats(const char *name, enum stat_frame_type frame_type, char **buffer,
-				size_t *length)
+static int log_add_tx_hwts_stats(const char *name, enum stat_frame_type frame_type, char **buffer,
+				 size_t *length)
 {
 	const struct statistics *stat = &global_statistics[frame_type];
 	int ret;
 
-	if (app_config.classes[frame_type].tx_hwtstamp_enabled &&
-	    app_config.classes[frame_type].xdp_enabled) {
+	if (app_config.classes[frame_type].tx_hwtstamp_enabled) {
 		ret = snprintf(*buffer, *length,
 			       "%sTxMin=%" PRIu64 " [us] | %sTxMax=%" PRIu64
 			       " [us] | %sTxAvg=%lf [us] | %sTxHwTimestampMissing=%" PRIu64 " | ",
@@ -305,7 +304,7 @@ static int log_add_traffic_class(const char *name, enum stat_frame_type frame_ty
 	if (ret)
 		return ret;
 
-	ret = log_add_xdp_tx_stats(name, frame_type, buffer, length);
+	ret = log_add_tx_hwts_stats(name, frame_type, buffer, length);
 	if (ret)
 		return ret;
 

--- a/src/log.c
+++ b/src/log.c
@@ -176,13 +176,13 @@ static int log_add_proc_batch_stats(const char *name, enum stat_frame_type frame
 	return 0;
 }
 
-static int log_add_xdp_rx_stats(const char *name, enum stat_frame_type frame_type, char **buffer,
-				size_t *length)
+static int log_add_rx_hwts_stats(const char *name, enum stat_frame_type frame_type, char **buffer,
+				 size_t *length)
 {
 	const struct statistics *stat = &global_statistics[frame_type];
 	int ret;
 
-	if (config_have_rx_timestamp() && app_config.classes[frame_type].xdp_enabled) {
+	if (config_class_rx_timestamp_enabled(frame_type)) {
 		ret = snprintf(*buffer, *length,
 			       "%sRxMin=%" PRIu64 " [us] | %sRxMax=%" PRIu64
 			       " [us] | %sRxAvg=%lf [us] | "
@@ -301,7 +301,7 @@ static int log_add_traffic_class(const char *name, enum stat_frame_type frame_ty
 	if (ret)
 		return ret;
 
-	ret = log_add_xdp_rx_stats(name, frame_type, buffer, length);
+	ret = log_add_rx_hwts_stats(name, frame_type, buffer, length);
 	if (ret)
 		return ret;
 

--- a/src/log.c
+++ b/src/log.c
@@ -186,14 +186,14 @@ static int log_add_rx_hwts_stats(const char *name, enum stat_frame_type frame_ty
 		ret = snprintf(*buffer, *length,
 			       "%sRxMin=%" PRIu64 " [us] | %sRxMax=%" PRIu64
 			       " [us] | %sRxAvg=%lf [us] | "
-			       "%sRxHw2XdpMin=%" PRIu64 " [us] | %sRxHw2XdpMax=%" PRIu64
-			       " [us] | %sRxHw2XdpAvg=%lf [us] | "
-			       "%sRxXdp2AppMin=%" PRIu64 " [us] | %sRxXdp2AppMax=%" PRIu64
-			       " [us] | %sRxXdp2AppAvg=%lf [us] | ",
+			       "%sRxHw2SwMin=%" PRIu64 " [us] | %sRxHw2SwMax=%" PRIu64
+			       " [us] | %sRxHw2SwAvg=%lf [us] | "
+			       "%sRxSw2AppMin=%" PRIu64 " [us] | %sRxSw2AppMax=%" PRIu64
+			       " [us] | %sRxSw2AppAvg=%lf [us] | ",
 			       name, stat->rx_min, name, stat->rx_max, name, stat->rx_avg, name,
-			       stat->rx_hw2xdp_min, name, stat->rx_hw2xdp_max, name,
-			       stat->rx_hw2xdp_avg, name, stat->rx_xdp2app_min, name,
-			       stat->rx_xdp2app_max, name, stat->rx_xdp2app_avg);
+			       stat->rx_hw2sw_min, name, stat->rx_hw2sw_max, name,
+			       stat->rx_hw2sw_avg, name, stat->rx_sw2app_min, name,
+			       stat->rx_sw2app_max, name, stat->rx_sw2app_avg);
 
 		return snprintf_err_handling(buffer, length, ret);
 	}

--- a/src/net.c
+++ b/src/net.c
@@ -273,8 +273,8 @@ static const char *hwtstamp_rx_filter_to_string(int filter)
 
 /*
  * Read-only diagnostic: does not touch rx_filter, so it can never clash with ptp4l. Explains
- * *why* the RxHw2Xdp/RxXdp2App (and possibly RxMin/Max/Avg) stats will read 0, since that would
- * otherwise be silent and hard to debug.
+ * *why* the RxMin/Max/Avg, RxHw2Sw/RxSw2App stats will read 0, since that would otherwise be
+ * silent and hard to debug.
  */
 static void warn_if_rx_hwtstamp_disabled(enum stat_frame_type frame_type)
 {
@@ -321,8 +321,8 @@ static void warn_if_rx_hwtstamp_disabled(enum stat_frame_type frame_type)
 	if (hwconfig.rx_filter != HWTSTAMP_FILTER_ALL && hwconfig.rx_filter != HWTSTAMP_FILTER_SOME)
 		fprintf(stderr,
 			"%s: RX HW timestamping on %s is limited to %s, not ALL. This traffic "
-			"class's own frames may not receive HW timestamps, so RxHw2Xdp/"
-			"RxXdp2App/Rx will read 0.\n"
+			"class's own frames may not receive HW timestamps, so RxMin/Max/Avg and "
+			"RxHw2Sw/RxSw2App will all read 0.\n"
 			"    Check actual driver capabilities with: ethtool -T %s\n",
 			tc, if_name, hwtstamp_rx_filter_to_string(hwconfig.rx_filter), if_name);
 }

--- a/src/net.c
+++ b/src/net.c
@@ -257,6 +257,76 @@ int get_interface_link_speed(const char *if_name, uint32_t *speed)
 	return 0;
 }
 
+static const char *hwtstamp_rx_filter_to_string(int filter)
+{
+	switch (filter) {
+	case HWTSTAMP_FILTER_NONE:
+		return "NONE";
+	case HWTSTAMP_FILTER_ALL:
+		return "ALL";
+	case HWTSTAMP_FILTER_SOME:
+		return "SOME";
+	default:
+		return "a PTP/NTP-only filter";
+	}
+}
+
+/*
+ * Read-only diagnostic: does not touch rx_filter, so it can never clash with ptp4l. Explains
+ * *why* the RxHw2Xdp/RxXdp2App (and possibly RxMin/Max/Avg) stats will read 0, since that would
+ * otherwise be silent and hard to debug.
+ */
+static void warn_if_rx_hwtstamp_disabled(enum stat_frame_type frame_type)
+{
+	const char *tc = stat_frame_type_to_string(frame_type);
+	const char *if_name = app_config.classes[frame_type].interface;
+	struct hwtstamp_config hwconfig = {};
+	struct ifreq ifreq = {0};
+	int socket_fd, ret;
+
+	socket_fd = socket(PF_INET, SOCK_DGRAM, IPPROTO_IP);
+	if (socket_fd < 0)
+		return;
+
+	strncpy(ifreq.ifr_name, if_name, sizeof(ifreq.ifr_name) - 1);
+	ifreq.ifr_data = (char *)&hwconfig;
+
+	ret = ioctl(socket_fd, SIOCGHWTSTAMP, &ifreq);
+	close(socket_fd);
+
+	if (ret < 0) {
+		fprintf(stderr,
+			"%s: Cannot query RX HW timestamp config on %s (SIOCGHWTSTAMP: %s). All "
+			"Rx HW timestamp stats will read 0 -- the driver may not support HW "
+			"timestamping at all.\n",
+			tc, if_name, strerror(errno));
+		return;
+	}
+
+	if (hwconfig.rx_filter == HWTSTAMP_FILTER_NONE) {
+		fprintf(stderr,
+			"%s: RX HW timestamping is not enabled on %s (rx_filter=NONE). All Rx HW "
+			"timestamp stats will read 0.\n"
+			"    Fix: start ptp4l with hardware timestamping (-H) before running "
+			"this application.\n",
+			tc, if_name);
+		return;
+	}
+
+	/*
+	 * ptp4l only ever requests a PTP/NTP specific filter for its own traffic. Many drivers
+	 * silently upscale that to HWTSTAMP_FILTER_ALL (the kernel explicitly permits this), but
+	 * some only ever timestamp the traffic they were asked for.
+	 */
+	if (hwconfig.rx_filter != HWTSTAMP_FILTER_ALL && hwconfig.rx_filter != HWTSTAMP_FILTER_SOME)
+		fprintf(stderr,
+			"%s: RX HW timestamping on %s is limited to %s, not ALL. This traffic "
+			"class's own frames may not receive HW timestamps, so RxHw2Xdp/"
+			"RxXdp2App/Rx will read 0.\n"
+			"    Check actual driver capabilities with: ethtool -T %s\n",
+			tc, if_name, hwtstamp_rx_filter_to_string(hwconfig.rx_filter), if_name);
+}
+
 static int create_socket(enum stat_frame_type frame_type, struct sock_filter *filter,
 			 size_t filter_len)
 {
@@ -285,6 +355,21 @@ static int create_socket(enum stat_frame_type frame_type, struct sock_filter *fi
 		fprintf(stderr, "Failed to mark %s socket as non-blocking!\n",
 			stat_frame_type_to_string(frame_type));
 		goto err_filter;
+	}
+
+	/* Enable RX HW/SW timestamp reporting. Best effort: driver may not support it. */
+	if (config_class_rx_timestamp_enabled(frame_type)) {
+		unsigned int ts_flags = SOF_TIMESTAMPING_RX_HARDWARE |
+					SOF_TIMESTAMPING_RX_SOFTWARE | SOF_TIMESTAMPING_SOFTWARE |
+					SOF_TIMESTAMPING_RAW_HARDWARE;
+
+		warn_if_rx_hwtstamp_disabled(frame_type);
+
+		ret = setsockopt(socket_fd, SOL_SOCKET, SO_TIMESTAMPING, &ts_flags,
+				 sizeof(ts_flags));
+		if (ret)
+			fprintf(stderr, "Failed to enable RX HW timestamping for %s: %s\n",
+				stat_frame_type_to_string(frame_type), strerror(errno));
 	}
 
 	/* Enable SO_TXTIME */

--- a/src/net.c
+++ b/src/net.c
@@ -327,6 +327,55 @@ static void warn_if_rx_hwtstamp_disabled(enum stat_frame_type frame_type)
 			tc, if_name, hwtstamp_rx_filter_to_string(hwconfig.rx_filter), if_name);
 }
 
+/* Shared by AF_XDP and AF_PACKET. Only touches tx_type; rx_filter is left to ptp4l. */
+int enable_hw_tx_timestamping(const char *if_name)
+{
+	struct ifreq ifr = {};
+	struct hwtstamp_config hwconfig = {};
+	int socket_fd;
+
+	socket_fd = socket(PF_INET, SOCK_DGRAM, 0);
+	if (socket_fd < 0) {
+		fprintf(stderr, "TxHwTs: Failed to create socket for interface %s: %s\n", if_name,
+			strerror(errno));
+		return -errno;
+	}
+
+	strncpy(ifr.ifr_name, if_name, IFNAMSIZ - 1);
+	ifr.ifr_name[IFNAMSIZ - 1] = '\0';
+	ifr.ifr_data = (char *)&hwconfig;
+
+	if (ioctl(socket_fd, SIOCGHWTSTAMP, &ifr) < 0) {
+		fprintf(stderr, "TxHwTs: Failed to read HW timestamp config for %s: %s\n", if_name,
+			strerror(errno));
+		close(socket_fd);
+		return -errno;
+	}
+
+	if (hwconfig.tx_type == HWTSTAMP_TX_ON) {
+		close(socket_fd);
+		return 0;
+	}
+
+	/* Only change TX type, keep RX settings */
+	hwconfig.tx_type = HWTSTAMP_TX_ON;
+	ifr.ifr_data = (char *)&hwconfig;
+
+	if (ioctl(socket_fd, SIOCSHWTSTAMP, &ifr) < 0) {
+		if (errno == EINVAL || errno == EOPNOTSUPP)
+			fprintf(stderr, "TxHwTs: HW timestamping not supported by driver on %s\n",
+				if_name);
+		else
+			fprintf(stderr, "TxHwTs: Failed to enable HW TX timestamping on %s: %s\n",
+				if_name, strerror(errno));
+		close(socket_fd);
+		return -errno;
+	}
+
+	close(socket_fd);
+	return 0;
+}
+
 static int create_socket(enum stat_frame_type frame_type, struct sock_filter *filter,
 			 size_t filter_len)
 {
@@ -370,6 +419,16 @@ static int create_socket(enum stat_frame_type frame_type, struct sock_filter *fi
 		if (ret)
 			fprintf(stderr, "Failed to enable RX HW timestamping for %s: %s\n",
 				stat_frame_type_to_string(frame_type), strerror(errno));
+	}
+
+	/* Enable TX HW timestamping on the interface. Explicit opt-in, so fail loudly. */
+	if (config_class_tx_timestamp_enabled(frame_type)) {
+		ret = enable_hw_tx_timestamping(app_config.classes[frame_type].interface);
+		if (ret) {
+			fprintf(stderr, "Failed to enable TX HW timestamping for %s!\n",
+				stat_frame_type_to_string(frame_type));
+			goto err_filter;
+		}
 	}
 
 	/* Enable SO_TXTIME */

--- a/src/net.h
+++ b/src/net.h
@@ -27,5 +27,6 @@ int create_udp_cl_socket(const char *udp_destination, const char *udp_port,
 			 struct sockaddr_storage *destination);
 int get_interface_mac_address(const char *if_name, unsigned char *mac, size_t len);
 int get_interface_link_speed(const char *if_name, uint32_t *speed);
+int enable_hw_tx_timestamping(const char *if_name);
 
 #endif /* _NET_H_ */

--- a/src/packet.c
+++ b/src/packet.c
@@ -16,6 +16,60 @@
 #include "tx_time.h"
 #include "utils.h"
 
+struct packet_rx_meta {
+	uint64_t rx_hw_timestamp;
+	uint64_t rx_sw_timestamp;
+};
+
+/* Frame data is preceded by a packet_rx_meta header within each rx_frames slot. */
+static inline unsigned char *packet_rx_payload(struct packet_context *context, size_t idx)
+{
+	return context->rx_frames + idx * (MAX_FRAME_SIZE + sizeof(struct packet_rx_meta)) +
+	       sizeof(struct packet_rx_meta);
+}
+
+static void packet_store_rx_timestamps(struct packet_context *context, struct mmsghdr *msgs,
+				       size_t num_msgs)
+{
+	size_t i;
+
+	for (i = 0; i < num_msgs; i++) {
+		struct packet_rx_meta *meta =
+			(struct packet_rx_meta *)(packet_rx_payload(context, i) - sizeof(*meta));
+		struct cmsghdr *cmsg;
+
+		meta->rx_hw_timestamp = 0;
+		meta->rx_sw_timestamp = 0;
+
+		for (cmsg = CMSG_FIRSTHDR(&msgs[i].msg_hdr); cmsg;
+		     cmsg = CMSG_NXTHDR(&msgs[i].msg_hdr, cmsg)) {
+			struct scm_timestamping *ts;
+
+			if (cmsg->cmsg_level != SOL_SOCKET || cmsg->cmsg_type != SCM_TIMESTAMPING)
+				continue;
+
+			ts = (struct scm_timestamping *)CMSG_DATA(cmsg);
+			if (ts->ts[2].tv_sec || ts->ts[2].tv_nsec)
+				meta->rx_hw_timestamp = ts_to_ns(&ts->ts[2]);
+			if (ts->ts[0].tv_sec || ts->ts[0].tv_nsec)
+				/*
+				 * Kernel SW RX timestamp is CLOCK_REALTIME; convert to
+				 * CLOCK_TAI to match rx_hw_timestamp and the app clock.
+				 */
+				meta->rx_sw_timestamp = ts_to_ns(&ts->ts[0]) + get_tai_offset_ns();
+			break;
+		}
+	}
+}
+
+void packet_get_timestamp_metadata(void *data, uint64_t *rx_hw_ts, uint64_t *rx_sw_ts)
+{
+	struct packet_rx_meta *meta = data - sizeof(*meta);
+
+	*rx_hw_ts = meta->rx_hw_timestamp;
+	*rx_sw_ts = meta->rx_sw_timestamp;
+}
+
 struct packet_context *packet_init(size_t num_frames_per_cycle)
 {
 	struct packet_context *context;
@@ -26,7 +80,8 @@ struct packet_context *packet_init(size_t num_frames_per_cycle)
 		return NULL;
 	}
 
-	context->rx_frames = calloc(MAX_FRAME_SIZE * num_frames_per_cycle, sizeof(unsigned char));
+	context->rx_frames =
+		calloc(num_frames_per_cycle, MAX_FRAME_SIZE + sizeof(struct packet_rx_meta));
 	if (!context->rx_frames) {
 		fprintf(stderr, "Failed to allocate receive frame buffers!\n");
 		goto err_rx_frames;
@@ -62,10 +117,18 @@ struct packet_context *packet_init(size_t num_frames_per_cycle)
 		goto err_tx_ctrl_msgs;
 	}
 
+	context->rx_control_msgs = calloc(num_frames_per_cycle, sizeof(*context->rx_control_msgs));
+	if (!context->rx_control_msgs) {
+		fprintf(stderr, "Failed to allocate receive control messages!\n");
+		goto err_rx_ctrl_msgs;
+	}
+
 	context->num_frames_per_cycle = num_frames_per_cycle;
 
 	return context;
 
+err_rx_ctrl_msgs:
+	free(context->tx_control_msgs);
 err_tx_ctrl_msgs:
 	free(context->tx_msgs);
 err_tx_msgs:
@@ -93,6 +156,7 @@ void packet_free(struct packet_context *context)
 	free(context->rx_msgs);
 	free(context->tx_msgs);
 	free(context->tx_control_msgs);
+	free(context->rx_control_msgs);
 	free(context);
 }
 
@@ -186,10 +250,19 @@ int packet_receive_messages(struct packet_context *context, struct packet_receiv
 		int len;
 
 		for (i = 0; i < context->num_frames_per_cycle; i++) {
-			iovecs[i].iov_base = frame_idx(context->rx_frames, i);
+			iovecs[i].iov_base = packet_rx_payload(context, i);
 			iovecs[i].iov_len = MAX_FRAME_SIZE;
 			msgs[i].msg_hdr.msg_iov = &iovecs[i];
 			msgs[i].msg_hdr.msg_iovlen = 1;
+
+			if (recv_req->rx_hwtstamp_enabled) {
+				msgs[i].msg_hdr.msg_control = context->rx_control_msgs[i].control;
+				msgs[i].msg_hdr.msg_controllen =
+					sizeof(context->rx_control_msgs[i].control);
+			} else {
+				msgs[i].msg_hdr.msg_control = NULL;
+				msgs[i].msg_hdr.msg_controllen = 0;
+			}
 		}
 
 		len = recvmmsg(recv_req->socket_fd, msgs, context->num_frames_per_cycle, 0, NULL);
@@ -203,9 +276,12 @@ int packet_receive_messages(struct packet_context *context, struct packet_receiv
 			break;
 		}
 
+		if (recv_req->rx_hwtstamp_enabled)
+			packet_store_rx_timestamps(context, msgs, (size_t)len);
+
 		/* Process received frames. */
 		for (i = 0; i < (size_t)len; i++)
-			recv_req->receive_function(recv_req->data, frame_idx(context->rx_frames, i),
+			recv_req->receive_function(recv_req->data, packet_rx_payload(context, i),
 						   msgs[i].msg_len);
 
 		received += len;

--- a/src/packet.c
+++ b/src/packet.c
@@ -9,6 +9,7 @@
 #include <unistd.h>
 
 #include <linux/if_packet.h>
+#include <linux/net_tstamp.h>
 
 #include "log.h"
 #include "packet.h"
@@ -123,10 +124,18 @@ struct packet_context *packet_init(size_t num_frames_per_cycle)
 		goto err_rx_ctrl_msgs;
 	}
 
+	context->tx_completion_frame = calloc(1, MAX_FRAME_SIZE);
+	if (!context->tx_completion_frame) {
+		fprintf(stderr, "Failed to allocate transmit completion frame buffer!\n");
+		goto err_tx_completion_frame;
+	}
+
 	context->num_frames_per_cycle = num_frames_per_cycle;
 
 	return context;
 
+err_tx_completion_frame:
+	free(context->rx_control_msgs);
 err_rx_ctrl_msgs:
 	free(context->tx_control_msgs);
 err_tx_ctrl_msgs:
@@ -157,6 +166,7 @@ void packet_free(struct packet_context *context)
 	free(context->tx_msgs);
 	free(context->tx_control_msgs);
 	free(context->rx_control_msgs);
+	free(context->tx_completion_frame);
 	free(context);
 }
 
@@ -192,29 +202,55 @@ int packet_send_messages(struct packet_context *context, struct packet_send_requ
 			msgs[i].msg_hdr.msg_name = send_req->destination;
 			msgs[i].msg_hdr.msg_namelen = sizeof(*send_req->destination);
 
-			/* In case the user configured Tx Time also add it. */
-			if (send_req->tx_time_enabled) {
+			/* In case the user configured Tx Time or Tx HW timestamping, add cmsgs. */
+			if (send_req->tx_time_enabled || send_req->tx_hwtstamp_enabled) {
 				unsigned char *control = context->tx_control_msgs[i].control;
-				uint64_t tx_time, sequence_counter;
+				uint64_t sequence_counter, frame_in_cycle;
 				struct cmsghdr *cmsg;
+				size_t controllen = 0;
 
 				sequence_counter =
 					get_sequence_counter(frame, send_req->meta_data_offset,
 							     context->num_frames_per_cycle);
+				frame_in_cycle = sequence_counter % context->num_frames_per_cycle;
 
-				tx_time = tx_time_get_frame_tx_time(
-					sequence_counter, send_req->duration,
-					context->num_frames_per_cycle, send_req->tx_time_offset,
-					send_req->traffic_class);
-
+				/* Full capacity while building; trimmed to controllen below. */
 				msgs[i].msg_hdr.msg_control = control;
 				msgs[i].msg_hdr.msg_controllen = sizeof(*context->tx_control_msgs);
-
 				cmsg = CMSG_FIRSTHDR(&msgs[i].msg_hdr);
-				cmsg->cmsg_level = SOL_SOCKET;
-				cmsg->cmsg_type = SO_TXTIME;
-				cmsg->cmsg_len = CMSG_LEN(sizeof(int64_t));
-				*((uint64_t *)CMSG_DATA(cmsg)) = tx_time;
+
+				if (send_req->tx_time_enabled) {
+					uint64_t tx_time = tx_time_get_frame_tx_time(
+						sequence_counter, send_req->duration,
+						context->num_frames_per_cycle,
+						send_req->tx_time_offset, send_req->traffic_class);
+
+					cmsg->cmsg_level = SOL_SOCKET;
+					cmsg->cmsg_type = SO_TXTIME;
+					cmsg->cmsg_len = CMSG_LEN(sizeof(uint64_t));
+					*((uint64_t *)CMSG_DATA(cmsg)) = tx_time;
+					controllen += CMSG_SPACE(sizeof(uint64_t));
+				}
+
+				/* Only the first/last frame of each cycle gets a HW timestamp. */
+				if (send_req->tx_hwtstamp_enabled &&
+				    (frame_in_cycle == 0 ||
+				     frame_in_cycle == context->num_frames_per_cycle - 1)) {
+					unsigned int ts_flags = SOF_TIMESTAMPING_TX_HARDWARE;
+
+					if (controllen)
+						cmsg = CMSG_NXTHDR(&msgs[i].msg_hdr, cmsg);
+					cmsg->cmsg_level = SOL_SOCKET;
+					cmsg->cmsg_type = SO_TIMESTAMPING;
+					cmsg->cmsg_len = CMSG_LEN(sizeof(ts_flags));
+					*((unsigned int *)CMSG_DATA(cmsg)) = ts_flags;
+					controllen += CMSG_SPACE(sizeof(ts_flags));
+				}
+
+				msgs[i].msg_hdr.msg_controllen = controllen;
+			} else {
+				msgs[i].msg_hdr.msg_control = NULL;
+				msgs[i].msg_hdr.msg_controllen = 0;
 			}
 		}
 
@@ -289,3 +325,85 @@ int packet_receive_messages(struct packet_context *context, struct packet_receiv
 
 	return received;
 }
+
+#ifdef TX_TIMESTAMP
+void packet_process_tx_completions(struct packet_context *context,
+				   const struct packet_tx_completion_request *req)
+{
+	struct round_trip_context *rtt = &round_trip_contexts[req->frame_type];
+
+	while (true) {
+		unsigned char *control = context->tx_completion_control.control;
+		unsigned char *frame = context->tx_completion_frame;
+		struct iovec iov = {.iov_base = frame, .iov_len = MAX_FRAME_SIZE};
+		struct msghdr msg = {
+			.msg_iov = &iov,
+			.msg_iovlen = 1,
+			.msg_control = control,
+			.msg_controllen = sizeof(context->tx_completion_control.control),
+		};
+		uint64_t seq, cycle_seq, frame_in_cycle, hw_ts = 0;
+		struct cmsghdr *cmsg;
+		bool is_first, is_last;
+		size_t idx;
+		ssize_t len;
+
+		len = recvmsg(req->socket_fd, &msg, MSG_ERRQUEUE | MSG_DONTWAIT);
+		if (len < 0)
+			break;
+
+		for (cmsg = CMSG_FIRSTHDR(&msg); cmsg; cmsg = CMSG_NXTHDR(&msg, cmsg)) {
+			struct scm_timestamping *ts;
+
+			if (cmsg->cmsg_level != SOL_SOCKET || cmsg->cmsg_type != SCM_TIMESTAMPING)
+				continue;
+
+			ts = (struct scm_timestamping *)CMSG_DATA(cmsg);
+			if (ts->ts[2].tv_sec || ts->ts[2].tv_nsec)
+				hw_ts = ts_to_ns(&ts->ts[2]);
+			break;
+		}
+
+		if (!hw_ts ||
+		    (size_t)len < req->meta_data_offset + sizeof(struct reference_meta_data)) {
+			log_message(LOG_LEVEL_DEBUG,
+				    "%sTxHwTs: Completion missing HW timestamp or echoed frame "
+				    "too short (%zd bytes), skipping\n",
+				    req->traffic_class, len);
+			continue;
+		}
+
+		/* Derive sequence counter from the echoed frame, same trick as AF_XDP. */
+		seq = get_sequence_counter(frame, req->meta_data_offset, req->num_frames_per_cycle);
+		cycle_seq = (seq / req->num_frames_per_cycle) * req->num_frames_per_cycle;
+		frame_in_cycle = seq - cycle_seq;
+		is_first = (frame_in_cycle == 0);
+		is_last = (frame_in_cycle == req->num_frames_per_cycle - 1);
+		idx = cycle_seq % rtt->backlog_len;
+
+		if (!rtt->backlog[idx].sw_ts)
+			continue;
+
+		/*
+		 * Only the first-frame completion updates hw_ts and calls stat_frame_sent_latency.
+		 */
+		if (is_first) {
+			rtt->backlog[idx].hw_ts = hw_ts;
+			stat_frame_sent_latency(req->frame_type, cycle_seq);
+		}
+
+		if (log_stat_user_selected == LOG_TX_TIMESTAMPS && config_have_rx_timestamp() &&
+		    hw_ts > rtt->backlog[idx].sw_ts) {
+			if (is_first)
+				stat_proc_first_latency(req->frame_type, cycle_seq, hw_ts);
+			else if (is_last)
+				stat_proc_batch_latency(req->frame_type, cycle_seq, hw_ts);
+		}
+	}
+}
+#else
+void packet_process_tx_completions(struct packet_context __unused *context,
+				   const struct packet_tx_completion_request __unused *req)
+{
+}
+#endif

--- a/src/packet.h
+++ b/src/packet.h
@@ -14,12 +14,24 @@
 #include <linux/errqueue.h>
 #include <sys/socket.h>
 
+#include "stat.h"
+
 struct tx_control_msg {
-	unsigned char control[CMSG_SPACE(sizeof(uint64_t))];
+	unsigned char control[CMSG_SPACE(sizeof(uint64_t)) + CMSG_SPACE(sizeof(unsigned int))];
 } __attribute((packed));
 
 struct rx_control_msg {
 	unsigned char control[CMSG_SPACE(sizeof(struct scm_timestamping))];
+} __attribute((packed));
+
+/*
+ * Sized for both the SCM_TIMESTAMPING cmsg and the SO_EE_ORIGIN_TIMESTAMPING error cmsg
+ * that comes with it on MSG_ERRQUEUE completions.
+ */
+struct tx_completion_control_msg {
+	unsigned char control[CMSG_SPACE(sizeof(struct sock_extended_err) +
+					 sizeof(struct sockaddr_storage)) +
+			      CMSG_SPACE(sizeof(struct scm_timestamping))];
 } __attribute((packed));
 
 struct packet_context {
@@ -30,6 +42,8 @@ struct packet_context {
 	struct mmsghdr *tx_msgs;
 	struct tx_control_msg *tx_control_msgs;
 	struct rx_control_msg *rx_control_msgs;
+	unsigned char *tx_completion_frame;
+	struct tx_completion_control_msg tx_completion_control;
 	size_t num_frames_per_cycle;
 };
 
@@ -48,6 +62,7 @@ struct packet_send_request {
 	uint32_t meta_data_offset;
 	bool mirror_enabled;
 	bool tx_time_enabled;
+	bool tx_hwtstamp_enabled;
 };
 
 int packet_send_messages(struct packet_context *context, struct packet_send_request *send_req);
@@ -65,5 +80,17 @@ int packet_receive_messages(struct packet_context *context,
 
 /* Retrieve RX HW/SW timestamps stashed by packet_receive_messages() for this frame. */
 void packet_get_timestamp_metadata(void *data, uint64_t *rx_hw_ts, uint64_t *rx_sw_ts);
+
+struct packet_tx_completion_request {
+	const char *traffic_class;
+	int socket_fd;
+	enum stat_frame_type frame_type;
+	uint32_t meta_data_offset;
+	size_t num_frames_per_cycle;
+};
+
+/* Drains pending TX HW timestamp completions from the error queue; no-op without TX_TIMESTAMP. */
+void packet_process_tx_completions(struct packet_context *context,
+				   const struct packet_tx_completion_request *req);
 
 #endif /* PACKET_H */

--- a/src/packet.h
+++ b/src/packet.h
@@ -11,10 +11,15 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <linux/errqueue.h>
 #include <sys/socket.h>
 
 struct tx_control_msg {
 	unsigned char control[CMSG_SPACE(sizeof(uint64_t))];
+} __attribute((packed));
+
+struct rx_control_msg {
+	unsigned char control[CMSG_SPACE(sizeof(struct scm_timestamping))];
 } __attribute((packed));
 
 struct packet_context {
@@ -24,6 +29,7 @@ struct packet_context {
 	struct mmsghdr *rx_msgs;
 	struct mmsghdr *tx_msgs;
 	struct tx_control_msg *tx_control_msgs;
+	struct rx_control_msg *rx_control_msgs;
 	size_t num_frames_per_cycle;
 };
 
@@ -51,9 +57,13 @@ struct packet_receive_request {
 	int socket_fd;
 	int (*receive_function)(void *data, unsigned char *, size_t);
 	void *data;
+	bool rx_hwtstamp_enabled;
 };
 
 int packet_receive_messages(struct packet_context *context,
 			    struct packet_receive_request *recv_req);
+
+/* Retrieve RX HW/SW timestamps stashed by packet_receive_messages() for this frame. */
+void packet_get_timestamp_metadata(void *data, uint64_t *rx_hw_ts, uint64_t *rx_sw_ts);
 
 #endif /* PACKET_H */

--- a/src/profinet.c
+++ b/src/profinet.c
@@ -10,6 +10,7 @@
 
 #include "log.h"
 #include "net_def.h"
+#include "packet.h"
 #include "ring_buffer.h"
 #include "thread.h"
 #include "utils.h"
@@ -302,6 +303,8 @@ int receive_profinet_frame(void *data, unsigned char *frame_data, size_t len)
 
 	if (config_have_rx_timestamp() && class_config->xdp_enabled)
 		xdp_get_timestamp_metadata(frame_data, &rx_hw_timestamp, &rx_sw_timestamp);
+	else if (config_have_rx_timestamp())
+		packet_get_timestamp_metadata(frame_data, &rx_hw_timestamp, &rx_sw_timestamp);
 	out_of_order = sequence_counter != thread_context->rx_sequence_counter;
 	payload_mismatch = memcmp(p, expected_pattern, expected_pattern_length);
 	frame_id_mismatch = frame_id != thread_context->frame_id;

--- a/src/stat.c
+++ b/src/stat.c
@@ -557,6 +557,11 @@ void stat_frame_sent_latency(enum stat_frame_type frame_type, uint64_t seq)
 
 	} else {
 		/* If HW timestamp isn't available after 1 cycle, consider it a miss */
+		log_message(LOG_LEVEL_DEBUG,
+			    "TxLatency [%s] Seq %" PRIu64
+			    ": Miss -- SW %llu ns, HW %llu ns, idx=%zu\n",
+			    stat_frame_type_to_string(frame_type), seq, (unsigned long long)sw_ts,
+			    (unsigned long long)hw_ts, idx);
 		stat->tx_hw_timestamp_missing++;
 		stat_per_period->tx_hw_timestamp_missing++;
 

--- a/src/stat.c
+++ b/src/stat.c
@@ -644,7 +644,13 @@ void stat_frame_received(enum stat_frame_type frame_type, uint64_t cycle_number,
 	oneway_time = (int64_t)curr_time - (int64_t)tx_timestamp;
 	oneway_time /= 1000;
 
-	if (rx_hw_timestamp != 0 && rx_sw_timestamp != 0) {
+	/*
+	 * Both timestamps are in the app's clock domain: AF_XDP's SW timestamp uses
+	 * bpf_ktime_get_tai_ns(), AF_PACKET's is converted from CLOCK_REALTIME to CLOCK_TAI via
+	 * get_tai_offset_ns() in packet.c.
+	 */
+	if (rx_hw_timestamp != 0 && rx_sw_timestamp != 0 && rx_hw_timestamp <= rx_sw_timestamp &&
+	    rx_sw_timestamp <= curr_time) {
 		/* Calculate Rx times */
 		rx_hw2app_time = curr_time - rx_hw_timestamp;
 		rx_hw2app_time /= 1000;
@@ -653,7 +659,7 @@ void stat_frame_received(enum stat_frame_type frame_type, uint64_t cycle_number,
 		rx_xdp2app_time = curr_time - rx_sw_timestamp;
 		rx_xdp2app_time /= 1000;
 	} else {
-		/* If one of the timestamp is not available, set them to zero */
+		/* Unavailable or, under clock jitter, out of order: zero instead of underflowing */
 		rx_hw2app_time = 0;
 		rx_hw2xdp_time = 0;
 		rx_xdp2app_time = 0;

--- a/src/stat.c
+++ b/src/stat.c
@@ -69,8 +69,8 @@ static void stat_reset(struct statistics *stats)
 	stats->oneway_min = INT64_MAX;
 	stats->oneway_max = INT64_MIN;
 	stats->rx_min = UINT64_MAX;
-	stats->rx_hw2xdp_min = UINT64_MAX;
-	stats->rx_xdp2app_min = UINT64_MAX;
+	stats->rx_hw2sw_min = UINT64_MAX;
+	stats->rx_sw2app_min = UINT64_MAX;
 	for (int i = 0; i < WORKLOAD_MAX; i++)
 		stats->workload[i].rx_workload_min = UINT64_MAX;
 	stats->tx_min = UINT64_MAX;
@@ -258,8 +258,8 @@ static inline size_t get_first_frame_backlog_idx(uint64_t cycle_number,
 static bool stat_frame_received_common(struct statistics *stat, enum stat_frame_type frame_type,
 				       uint64_t rt_time, int64_t oneway_time, bool out_of_order,
 				       bool payload_mismatch, bool frame_id_mismatch,
-				       uint64_t rx_hw2app_time, uint64_t rx_hw2xdp_time,
-				       uint64_t rx_xdp2app_time)
+				       uint64_t rx_hw2app_time, uint64_t rx_hw2sw_time,
+				       uint64_t rx_sw2app_time)
 {
 	bool outlier = false;
 
@@ -287,20 +287,20 @@ static bool stat_frame_received_common(struct statistics *stat, enum stat_frame_
 	stat->oneway_sum += oneway_time;
 	stat->oneway_avg = stat->oneway_sum / (double)stat->oneway_count;
 
-	if (rx_hw2app_time != 0 && rx_hw2xdp_time != 0 && rx_xdp2app_time != 0) {
+	if (rx_hw2app_time != 0 && rx_hw2sw_time != 0 && rx_sw2app_time != 0) {
 		stat->rx_count++;
 
 		stat_update_min_max(rx_hw2app_time, &stat->rx_min, &stat->rx_max);
 		stat->rx_sum += rx_hw2app_time;
 		stat->rx_avg = stat->rx_sum / (double)stat->rx_count;
 
-		stat_update_min_max(rx_hw2xdp_time, &stat->rx_hw2xdp_min, &stat->rx_hw2xdp_max);
-		stat->rx_hw2xdp_sum += rx_hw2xdp_time;
-		stat->rx_hw2xdp_avg = stat->rx_hw2xdp_sum / (double)stat->rx_count;
+		stat_update_min_max(rx_hw2sw_time, &stat->rx_hw2sw_min, &stat->rx_hw2sw_max);
+		stat->rx_hw2sw_sum += rx_hw2sw_time;
+		stat->rx_hw2sw_avg = stat->rx_hw2sw_sum / (double)stat->rx_count;
 
-		stat_update_min_max(rx_xdp2app_time, &stat->rx_xdp2app_min, &stat->rx_xdp2app_max);
-		stat->rx_xdp2app_sum += rx_xdp2app_time;
-		stat->rx_xdp2app_avg = stat->rx_xdp2app_sum / (double)stat->rx_count;
+		stat_update_min_max(rx_sw2app_time, &stat->rx_sw2app_min, &stat->rx_sw2app_max);
+		stat->rx_sw2app_sum += rx_sw2app_time;
+		stat->rx_sw2app_avg = stat->rx_sw2app_sum / (double)stat->rx_count;
 	}
 
 	stat->frames_received++;
@@ -350,15 +350,15 @@ static void stat_frame_proc_batch_common(struct statistics *stat, uint64_t proc_
 static void stat_frame_received_per_period(enum stat_frame_type frame_type, uint64_t curr_time,
 					   uint64_t rt_time, int64_t oneway_time, bool out_of_order,
 					   bool payload_mismatch, bool frame_id_mismatch,
-					   uint64_t rx_hw2app_time, uint64_t rx_hw2xdp_time,
-					   uint64_t rx_xdp2app_time)
+					   uint64_t rx_hw2app_time, uint64_t rx_hw2sw_time,
+					   uint64_t rx_sw2app_time)
 {
 	struct statistics *stat_per_period = &statistics_per_period[frame_type];
 
 	stat_per_period->time_stamp = curr_time;
 	stat_frame_received_common(stat_per_period, frame_type, rt_time, oneway_time, out_of_order,
 				   payload_mismatch, frame_id_mismatch, rx_hw2app_time,
-				   rx_hw2xdp_time, rx_xdp2app_time);
+				   rx_hw2sw_time, rx_sw2app_time);
 }
 
 static void stat_frame_sent_per_period(enum stat_frame_type frame_type)
@@ -419,7 +419,7 @@ static void stat_frame_received_per_period(enum stat_frame_type frame_type, uint
 					   uint64_t rt_time, bool out_of_order,
 					   bool payload_mismatch, bool frame_id_mismatch,
 					   uint64_t tx_timestamp, uint64_t rx_hw2app_time,
-					   uint64_t rx_hw2xdp_time, uint64_t rx_xdp2app_time)
+					   uint64_t rx_hw2sw_time, uint64_t rx_sw2app_time)
 {
 }
 
@@ -578,7 +578,7 @@ void stat_frame_received(enum stat_frame_type frame_type, uint64_t cycle_number,
 			 bool payload_mismatch, bool frame_id_mismatch, uint64_t tx_timestamp,
 			 uint64_t rx_hw_timestamp, uint64_t rx_sw_timestamp)
 {
-	uint64_t rt_time = 0, curr_time, rx_hw2app_time, rx_hw2xdp_time, rx_xdp2app_time;
+	uint64_t rt_time = 0, curr_time, rx_hw2app_time, rx_hw2sw_time, rx_sw2app_time;
 	struct round_trip_context *rtt = &round_trip_contexts[frame_type];
 	const bool histogram = app_config.stats_histogram_enabled;
 	struct statistics *stat = &global_statistics[frame_type];
@@ -659,26 +659,26 @@ void stat_frame_received(enum stat_frame_type frame_type, uint64_t cycle_number,
 		/* Calculate Rx times */
 		rx_hw2app_time = curr_time - rx_hw_timestamp;
 		rx_hw2app_time /= 1000;
-		rx_hw2xdp_time = rx_sw_timestamp - rx_hw_timestamp;
-		rx_hw2xdp_time /= 1000;
-		rx_xdp2app_time = curr_time - rx_sw_timestamp;
-		rx_xdp2app_time /= 1000;
+		rx_hw2sw_time = rx_sw_timestamp - rx_hw_timestamp;
+		rx_hw2sw_time /= 1000;
+		rx_sw2app_time = curr_time - rx_sw_timestamp;
+		rx_sw2app_time /= 1000;
 	} else {
 		/* Unavailable or, under clock jitter, out of order: zero instead of underflowing */
 		rx_hw2app_time = 0;
-		rx_hw2xdp_time = 0;
-		rx_xdp2app_time = 0;
+		rx_hw2sw_time = 0;
+		rx_sw2app_time = 0;
 	}
 
 	/* Update global stats */
 	outlier = stat_frame_received_common(stat, frame_type, rt_time, oneway_time, out_of_order,
 					     payload_mismatch, frame_id_mismatch, rx_hw2app_time,
-					     rx_hw2xdp_time, rx_xdp2app_time);
+					     rx_hw2sw_time, rx_sw2app_time);
 
 	/* Update stats per collection interval */
 	stat_frame_received_per_period(frame_type, curr_time, rt_time, oneway_time, out_of_order,
 				       payload_mismatch, frame_id_mismatch, rx_hw2app_time,
-				       rx_hw2xdp_time, rx_xdp2app_time);
+				       rx_hw2sw_time, rx_sw2app_time);
 
 	/* Stop tracing after certain amount of time */
 	if (app_config.debug_stop_trace_on_outlier && outlier) {
@@ -1034,27 +1034,27 @@ int stat_to_json(char *json, size_t len, enum stat_frame_type frame_type,
 	if (ret)
 		return ret;
 
-	ret = append_jlog_u64(&json, &len, "RxHw2XdpMin", stat->rx_hw2xdp_min);
+	ret = append_jlog_u64(&json, &len, "RxHw2SwMin", stat->rx_hw2sw_min);
 	if (ret)
 		return ret;
 
-	ret = append_jlog_u64(&json, &len, "RxHw2XdpMax", stat->rx_hw2xdp_max);
+	ret = append_jlog_u64(&json, &len, "RxHw2SwMax", stat->rx_hw2sw_max);
 	if (ret)
 		return ret;
 
-	ret = append_jlog_float(&json, &len, "RxHw2XdpAv", stat->rx_hw2xdp_avg);
+	ret = append_jlog_float(&json, &len, "RxHw2SwAv", stat->rx_hw2sw_avg);
 	if (ret)
 		return ret;
 
-	ret = append_jlog_u64(&json, &len, "RxXdp2AppMin", stat->rx_xdp2app_min);
+	ret = append_jlog_u64(&json, &len, "RxSw2AppMin", stat->rx_sw2app_min);
 	if (ret)
 		return ret;
 
-	ret = append_jlog_u64(&json, &len, "RxXdp2AppMax", stat->rx_xdp2app_max);
+	ret = append_jlog_u64(&json, &len, "RxSw2AppMax", stat->rx_sw2app_max);
 	if (ret)
 		return ret;
 
-	ret = append_jlog_float(&json, &len, "RxXdp2AppAv", stat->rx_xdp2app_avg);
+	ret = append_jlog_float(&json, &len, "RxSw2AppAv", stat->rx_sw2app_avg);
 	if (ret)
 		return ret;
 

--- a/src/stat.h
+++ b/src/stat.h
@@ -104,16 +104,16 @@ struct statistics {
 	uint64_t rx_count;
 	double rx_sum;
 	double rx_avg;
-	/* Rx latency from NIC Rx Hw timestamp to Xdp prog timestamp */
-	uint64_t rx_hw2xdp_min;
-	uint64_t rx_hw2xdp_max;
-	double rx_hw2xdp_sum;
-	double rx_hw2xdp_avg;
-	/* Rx latency from Xdp prog timestamp to user space timestamp */
-	uint64_t rx_xdp2app_min;
-	uint64_t rx_xdp2app_max;
-	double rx_xdp2app_sum;
-	double rx_xdp2app_avg;
+	/* Rx latency from NIC Rx Hw timestamp to earliest SW (XDP or kernel) timestamp */
+	uint64_t rx_hw2sw_min;
+	uint64_t rx_hw2sw_max;
+	double rx_hw2sw_sum;
+	double rx_hw2sw_avg;
+	/* Rx latency from earliest SW timestamp to user space timestamp */
+	uint64_t rx_sw2app_min;
+	uint64_t rx_sw2app_max;
+	double rx_sw2app_sum;
+	double rx_sw2app_avg;
 	/* Workload statistics */
 	struct workload_statistics workload[WORKLOAD_MAX];
 	/* Tx latency from user space (at send) to NIC Tx HW timestamp */

--- a/src/tc.c
+++ b/src/tc.c
@@ -186,6 +186,25 @@ static void tc_initialize_frames(struct thread_context *ctx, unsigned char *fram
 	}
 }
 
+/*
+ * Draining must happen after the caller records its Tx SW timestamp: a completion can
+ * arrive fast enough that draining first would make the recorded SW timestamp race behind
+ * the real HW Tx timestamp, turning valid completions into false TxHwTimestampMissing misses.
+ */
+static void tc_process_tx_completions(struct thread_context *ctx, int socket_fd)
+{
+	const struct traffic_class_config *conf = ctx->conf;
+	struct packet_tx_completion_request completion_req = {
+		.traffic_class = ctx->traffic_class,
+		.socket_fd = socket_fd,
+		.frame_type = ctx->frame_type,
+		.meta_data_offset = ctx->meta_data_offset,
+		.num_frames_per_cycle = conf->num_frames_per_cycle,
+	};
+
+	packet_process_tx_completions(ctx->packet_context, &completion_req);
+}
+
 static int tc_send_messages(struct thread_context *ctx, int socket_fd,
 			    struct sockaddr_ll *destination, unsigned char *frame_data,
 			    size_t num_frames, uint64_t duration)
@@ -203,6 +222,7 @@ static int tc_send_messages(struct thread_context *ctx, int socket_fd,
 		.meta_data_offset = ctx->meta_data_offset,
 		.mirror_enabled = conf->rx_mirror_enabled,
 		.tx_time_enabled = conf->tx_time_enabled,
+		.tx_hwtstamp_enabled = config_class_tx_timestamp_enabled(ctx->frame_type),
 	};
 
 	return packet_send_messages(ctx->packet_context, &send_req);
@@ -230,6 +250,9 @@ static int tc_send_frames(struct thread_context *ctx, unsigned char *frame_data,
 
 		stat_frame_sent(ctx->frame_type, sequence_counter);
 	}
+
+	if (config_class_tx_timestamp_enabled(ctx->frame_type))
+		tc_process_tx_completions(ctx, socket_fd);
 
 	return len;
 }
@@ -275,6 +298,9 @@ static int tc_gen_and_send_frames(struct thread_context *ctx, int socket_fd,
 
 	if (len > 0)
 		stat_frames_sent_batch(ctx->frame_type, sequence_counter_begin, len);
+
+	if (config_class_tx_timestamp_enabled(ctx->frame_type))
+		tc_process_tx_completions(ctx, socket_fd);
 
 	return len;
 }

--- a/src/tc.c
+++ b/src/tc.c
@@ -518,6 +518,7 @@ void *tc_rx_thread(void *data)
 {
 	struct thread_context *ctx = data;
 	const uint64_t cycle_time_ns = app_config.application_base_cycle_time_ns;
+	const bool rx_hwtstamp_enabled = config_class_rx_timestamp_enabled(ctx->frame_type);
 	int socket_fd, ret, received;
 	struct timespec wakeup_time;
 
@@ -538,6 +539,7 @@ void *tc_rx_thread(void *data)
 			.socket_fd = socket_fd,
 			.receive_function = ctx->desc->ops.receive_frame,
 			.data = ctx,
+			.rx_hwtstamp_enabled = rx_hwtstamp_enabled,
 		};
 
 		/* Wait until next period. */

--- a/src/utils.c
+++ b/src/utils.c
@@ -15,6 +15,7 @@
 #include <arpa/inet.h>
 
 #include <sys/stat.h>
+#include <sys/timex.h>
 #include <sys/types.h>
 
 #include <linux/if_ether.h>
@@ -303,6 +304,17 @@ void print_cpu_list(const int *cpus, size_t cpus_len)
 			printf(", ");
 	}
 	printf("\n");
+}
+
+int64_t get_tai_offset_ns(void)
+{
+	static int64_t tai_offset_ns = INT64_MIN; /* Not yet queried */
+	struct timex tx = {};
+
+	if (tai_offset_ns == INT64_MIN)
+		tai_offset_ns = adjtimex(&tx) < 0 ? 0 : (int64_t)tx.tai * NSEC_PER_SEC;
+
+	return tai_offset_ns;
 }
 
 void print_clockid(clockid_t clock)

--- a/src/utils.h
+++ b/src/utils.h
@@ -95,6 +95,9 @@ void prepare_openssl(struct security_context *context);
 
 int get_thread_start_time(uint64_t base_offset, struct timespec *wakeup_time);
 
+/* Returns CLOCK_TAI minus CLOCK_REALTIME, in ns (0 if not set by ptp4l/phc2sys). */
+int64_t get_tai_offset_ns(void);
+
 void configure_cpu_latency(void);
 void restore_cpu_latency(void);
 

--- a/src/xdp.c
+++ b/src/xdp.c
@@ -58,73 +58,6 @@ static void xdp_set_prog_bind_flags(struct bpf_object __unused *obj, unsigned in
 }
 
 #ifdef TX_TIMESTAMP
-static int xdp_enable_hw_tx_timestamping(const char *if_name)
-{
-	struct ifreq ifr = {};
-	struct hwtstamp_config hwconfig = {};
-	int socket_fd;
-
-	socket_fd = socket(PF_INET, SOCK_DGRAM, 0);
-	if (socket_fd < 0) {
-		fprintf(stderr, "XdpTxHwTs: Failed to create socket for interface %s: %s\n",
-			if_name, strerror(errno));
-		return -errno;
-	}
-
-	strncpy(ifr.ifr_name, if_name, IFNAMSIZ - 1);
-	ifr.ifr_name[IFNAMSIZ - 1] = '\0';
-	ifr.ifr_data = (char *)&hwconfig;
-
-	if (ioctl(socket_fd, SIOCGHWTSTAMP, &ifr) < 0) {
-		fprintf(stderr, "XdpTxHwTs: Failed to read HW timestamp config for %s: %s\n",
-			if_name, strerror(errno));
-		close(socket_fd);
-		return -errno;
-	}
-
-	if (hwconfig.rx_filter != HWTSTAMP_FILTER_NONE) {
-		log_message(
-			LOG_LEVEL_INFO,
-			"XdpTxHwTs: ptp4l or another service already configured RX HW timestamping "
-			"on %s — keeping existing RX settings\n",
-			if_name);
-	}
-
-	if (hwconfig.tx_type == HWTSTAMP_TX_ON) {
-		log_message(
-			LOG_LEVEL_INFO,
-			"XdpTxHwTs: TX HW timestamping already enabled on %s — skipping reapply\n",
-			if_name);
-		close(socket_fd);
-		return 0;
-	}
-
-	/* Only change TX type, keep RX settings */
-	hwconfig.tx_type = HWTSTAMP_TX_ON;
-	ifr.ifr_data = (char *)&hwconfig;
-
-	if (ioctl(socket_fd, SIOCSHWTSTAMP, &ifr) < 0) {
-		if (errno == EINVAL || errno == EOPNOTSUPP) {
-			fprintf(stderr,
-				"XdpTxHwTs: HW timestamping not supported by driver on %s\n",
-				if_name);
-		} else {
-			fprintf(stderr,
-				"XdpTxHwTs: Failed to enable HW TX timestamping on %s: %s\n",
-				if_name, strerror(errno));
-		}
-		close(socket_fd);
-		return -errno;
-	}
-
-	log_message(
-		LOG_LEVEL_INFO,
-		"XdpTxHwTs: HW TX timestamping enabled for interface %s (RX config preserved)\n",
-		if_name);
-	close(socket_fd);
-	return 0;
-}
-
 static void xdp_process_tx_timestamp(struct xdp_socket *xsk, uint32_t idx_cq)
 {
 	struct round_trip_context *rtt = xsk->tx_hwts.rtt;
@@ -433,7 +366,7 @@ struct xdp_socket *xdp_open_socket(const char *interface, const char *xdp_progra
 #ifdef TX_TIMESTAMP
 	/* Enable HW TX timestamping if requested */
 	if (tx_hwtstamp_mode) {
-		ret = xdp_enable_hw_tx_timestamping(interface);
+		ret = enable_hw_tx_timestamping(interface);
 		if (ret) {
 			fprintf(stderr, "Failed to enable HW TX timestamping on %s!\n", interface);
 			goto err_hw_ts;


### PR DESCRIPTION
- Mirrors AF_XDP's existing RX & TX HW timestamp support for AF_PACKET sockets.
- Reuses the existing build flag and TxTimeStampEnabled per-class option.
- Scope matches AF_XDP: TSN_HIGH, TSN_LOW, RTC, RTA, GenericL2 (TC_XDP).